### PR TITLE
Separate DMAChan into a DMAChannelDir and channelIndex

### DIFF
--- a/include/aie/AIE.td
+++ b/include/aie/AIE.td
@@ -890,7 +890,7 @@ def AIE_PacketDestOp: AIE_Op<"packet_dest", [HasParent<"PacketFlowOp">]> {
 def S2MM:  I32EnumAttrCase<"S2MM", 0>;
 def MM2S:  I32EnumAttrCase<"MM2S", 1>;
 
-def DMAChan: I32EnumAttr<"DMAChan", "DMA Channel direction",
+def DMAChannelDir: I32EnumAttr<"DMAChannelDir", "DMA Channel direction",
   [S2MM, MM2S]> {
 
   let cppNamespace = "xilinx::AIE";
@@ -1018,23 +1018,23 @@ def AIE_DMAStartOp: AIE_Op<"dmaStart", [ParentOneOf<["MemOp", "func::FuncOp", "S
   }];
 
   let arguments = (
-    ins DMAChan:$dmaChan, 
+    ins DMAChannelDir:$channelDir, 
         ConfinedAttr<I32Attr, [IntMinValue<0>, IntMaxValue<1>]>:$channelIndex
   );
   let successors = (successor AnySuccessor:$dest, AnySuccessor:$chain);
   let assemblyFormat = [{
-    `(` $dmaChan `,` $channelIndex `,` $dest `,` $chain `)` attr-dict
+    `(` $channelDir `,` $channelIndex `,` $dest `,` $chain `)` attr-dict
   }];
 
   let extraClassDeclaration = [{
-    bool isSend() { return (static_cast<int32_t>(dmaChan()) == 0); }
-    bool isRecv() { return (static_cast<int32_t>(dmaChan()) == 1); }
+    bool isSend() { return (static_cast<int32_t>(channelDir()) == 0); }
+    bool isRecv() { return (static_cast<int32_t>(channelDir()) == 1); }
   }];
 
   let builders = [
-    OpBuilder<(ins "DMAChan":$channel, "int":$channelIndex, "Block *":$dest, "Block *":$chain),
+    OpBuilder<(ins "DMAChannelDir":$channelDir, "int":$channelIndex, "Block *":$dest, "Block *":$chain),
     [{
-              build($_builder, $_state, $_builder.getIntegerType(1), channel, channelIndex, dest, chain);
+              build($_builder, $_state, $_builder.getIntegerType(1), channelDir, channelIndex, dest, chain);
               }]>
   ];
 }

--- a/include/aie/AIE.td
+++ b/include/aie/AIE.td
@@ -887,13 +887,11 @@ def AIE_PacketDestOp: AIE_Op<"packet_dest", [HasParent<"PacketFlowOp">]> {
   }];
 }
 
-def S2MM0:  I32EnumAttrCase<"S2MM0", 0>;
-def S2MM1:  I32EnumAttrCase<"S2MM1", 1>;
-def MM2S0:  I32EnumAttrCase<"MM2S0", 2>;
-def MM2S1:  I32EnumAttrCase<"MM2S1", 3>;
+def S2MM:  I32EnumAttrCase<"S2MM", 0>;
+def MM2S:  I32EnumAttrCase<"MM2S", 1>;
 
-def DMAChan: I32EnumAttr<"DMAChan", "DMA Channel number",
-  [S2MM0, S2MM1, MM2S0, MM2S1]> {
+def DMAChan: I32EnumAttr<"DMAChan", "DMA Channel direction",
+  [S2MM, MM2S]> {
 
   let cppNamespace = "xilinx::AIE";
 }
@@ -1019,32 +1017,24 @@ def AIE_DMAStartOp: AIE_Op<"dmaStart", [ParentOneOf<["MemOp", "func::FuncOp", "S
     or to a basic block for another dmaStart, to an AIE.end operation.
   }];
 
-  let arguments = (ins DMAChan:$dmaChan);
+  let arguments = (
+    ins DMAChan:$dmaChan, 
+        ConfinedAttr<I32Attr, [IntMinValue<0>, IntMaxValue<1>]>:$channelIndex
+  );
   let successors = (successor AnySuccessor:$dest, AnySuccessor:$chain);
   let assemblyFormat = [{
-    `(` $dmaChan `,` $dest `,` $chain `)` attr-dict
+    `(` $dmaChan `,` $channelIndex `,` $dest `,` $chain `)` attr-dict
   }];
 
   let extraClassDeclaration = [{
-    bool isSend() { return ((static_cast<int32_t>(dmaChan()) == 2) ||
-                            (static_cast<int32_t>(dmaChan()) == 3)); }
-    bool isRecv() { return ((static_cast<int32_t>(dmaChan()) == 0) ||
-                            (static_cast<int32_t>(dmaChan()) == 1)); }
-    int getSendChannelIndex() {
-      return static_cast<int32_t>(dmaChan()) - 2;
-    }
-    int getRecvChannelIndex() {
-      return static_cast<int32_t>(dmaChan()) - 0;
-    }
-    int getChannelNum() {
-      return static_cast<int32_t>(dmaChan());
-    }
+    bool isSend() { return (static_cast<int32_t>(dmaChan()) == 0); }
+    bool isRecv() { return (static_cast<int32_t>(dmaChan()) == 1); }
   }];
 
   let builders = [
-    OpBuilder<(ins "DMAChan":$channel, "Block *":$dest, "Block *":$chain),
+    OpBuilder<(ins "DMAChan":$channel, "int":$channelIndex, "Block *":$dest, "Block *":$chain),
     [{
-              build($_builder, $_state, $_builder.getIntegerType(1), channel, dest, chain);
+              build($_builder, $_state, $_builder.getIntegerType(1), channel, channelIndex, dest, chain);
               }]>
   ];
 }

--- a/include/aie/AIEDialect.h
+++ b/include/aie/AIEDialect.h
@@ -162,6 +162,7 @@ public:
 typedef std::pair<WireBundle, int> Port;
 typedef std::pair<Port, Port> Connect;
 typedef std::pair<int, int> TileID;
+typedef std::pair<DMAChan, int> DMAChannel;
 
 bool isValidTile(TileID src);
 

--- a/include/aie/AIEDialect.h
+++ b/include/aie/AIEDialect.h
@@ -162,7 +162,7 @@ public:
 typedef std::pair<WireBundle, int> Port;
 typedef std::pair<Port, Port> Connect;
 typedef std::pair<int, int> TileID;
-typedef std::pair<DMAChan, int> DMAChannel;
+typedef std::pair<DMAChannelDir, int> DMAChannel;
 
 bool isValidTile(TileID src);
 

--- a/lib/AIEDialect.cpp
+++ b/lib/AIEDialect.cpp
@@ -735,7 +735,7 @@ LogicalResult xilinx::AIE::MemOp::verify() {
             << "Duplicate DMA channel " 
             << stringifyDMAChan(dmaChan.first) << dmaChan.second
             << " detected in MemOp!";
-      used_channels.insert(DMA_chan);
+      used_channels.insert(dmaChan);
     }
 
     if (auto allocOp = dyn_cast<memref::AllocOp>(bodyOp)) {

--- a/lib/AIEDialect.cpp
+++ b/lib/AIEDialect.cpp
@@ -729,11 +729,11 @@ LogicalResult xilinx::AIE::MemOp::verify() {
     // check for duplicate DMA channels within the same MemOp
     if (auto DMA_start = dyn_cast<xilinx::AIE::DMAStartOp>(bodyOp)) {
       xilinx::AIE::DMAChannel dmaChan =
-          std::make_pair(DMA_start.dmaChan(), DMA_start.channelIndex());
+          std::make_pair(DMA_start.channelDir(), DMA_start.channelIndex());
       if (used_channels.count(dmaChan))
         DMA_start.emitOpError()
             << "Duplicate DMA channel " 
-            << stringifyDMAChan(dmaChan.first) << dmaChan.second
+            << stringifyDMAChannelDir(dmaChan.first) << dmaChan.second
             << " detected in MemOp!";
       used_channels.insert(dmaChan);
     }

--- a/lib/AIEDialect.cpp
+++ b/lib/AIEDialect.cpp
@@ -732,9 +732,8 @@ LogicalResult xilinx::AIE::MemOp::verify() {
           std::make_pair(DMA_start.channelDir(), DMA_start.channelIndex());
       if (used_channels.count(dmaChan))
         DMA_start.emitOpError()
-            << "Duplicate DMA channel " 
-            << stringifyDMAChannelDir(dmaChan.first) << dmaChan.second
-            << " detected in MemOp!";
+            << "Duplicate DMA channel " << stringifyDMAChannelDir(dmaChan.first)
+            << dmaChan.second << " detected in MemOp!";
       used_channels.insert(dmaChan);
     }
 

--- a/lib/AIEDialect.cpp
+++ b/lib/AIEDialect.cpp
@@ -728,8 +728,8 @@ LogicalResult xilinx::AIE::MemOp::verify() {
   for (auto &bodyOp : getBody().getOps()) {
     // check for duplicate DMA channels within the same MemOp
     if (auto DMA_start = dyn_cast<xilinx::AIE::DMAStartOp>(bodyOp)) {
-      xilinx::AIE::DMAChannel dmaChan =
-          std::make_pair(DMA_start.getChannelDir(), DMA_start.getChannelIndex());
+      xilinx::AIE::DMAChannel dmaChan = std::make_pair(
+          DMA_start.getChannelDir(), DMA_start.getChannelIndex());
       if (used_channels.count(dmaChan))
         DMA_start.emitOpError()
             << "Duplicate DMA channel " << stringifyDMAChannelDir(dmaChan.first)

--- a/lib/AIELowerMemcpy.cpp
+++ b/lib/AIELowerMemcpy.cpp
@@ -40,7 +40,7 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
 
   void createDMABlocksAndOps(MemOp &mem, StringRef tokenName, int acquireTknVal,
                              int releaseTknVal, Value buf, int offset, int len,
-                             DMAChan dmaChannel, int channelIndex,
+                             DMAChannelDir dmaDir, int channelIndex,
                              ConversionPatternRewriter &rewriter) const {
 
     Region &r = mem.body();
@@ -49,7 +49,7 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     Block *bdBlock = rewriter.createBlock(&endBlock);
 
     rewriter.setInsertionPointToStart(dmaBlock);
-    rewriter.create<DMAStartOp>(rewriter.getUnknownLoc(), dmaChannel, channelIndex, 
+    rewriter.create<DMAStartOp>(rewriter.getUnknownLoc(), dmaDir, channelIndex, 
                                 bdBlock, &endBlock);
 
     // Setup bd Block
@@ -84,9 +84,9 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     MemOp dstMem = dstTileOp(op).getMemOp();
 
     createDMABlocksAndOps(srcMem, tokenName, acquireTknVal, releaseTknVal,
-                          srcBuf, srcOffset, srcLen, DMAChan::MM2S, 0, rewriter);
+                          srcBuf, srcOffset, srcLen, DMAChannelDir::MM2S, 0, rewriter);
     createDMABlocksAndOps(dstMem, tokenName, acquireTknVal, releaseTknVal,
-                          dstBuf, dstOffset, dstLen, DMAChan::S2MM, 0, rewriter);
+                          dstBuf, dstOffset, dstLen, DMAChannelDir::S2MM, 0, rewriter);
 
     rewriter.eraseOp(Op);
     return success();

--- a/lib/AIELowerMemcpy.cpp
+++ b/lib/AIELowerMemcpy.cpp
@@ -40,7 +40,7 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
 
   void createDMABlocksAndOps(MemOp &mem, StringRef tokenName, int acquireTknVal,
                              int releaseTknVal, Value buf, int offset, int len,
-                             DMAChan dmaChannel,
+                             DMAChan dmaChannel, int channelIndex,
                              ConversionPatternRewriter &rewriter) const {
 
     Region &r = mem.body();
@@ -49,8 +49,8 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     Block *bdBlock = rewriter.createBlock(&endBlock);
 
     rewriter.setInsertionPointToStart(dmaBlock);
-    rewriter.create<DMAStartOp>(rewriter.getUnknownLoc(), dmaChannel, bdBlock,
-                                &endBlock);
+    rewriter.create<DMAStartOp>(rewriter.getUnknownLoc(), dmaChannel, channelIndex, 
+                                bdBlock, &endBlock);
 
     // Setup bd Block
     // It should contain locking operations (lock or token) as well as DMABD op
@@ -84,9 +84,9 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     MemOp dstMem = dstTileOp(op).getMemOp();
 
     createDMABlocksAndOps(srcMem, tokenName, acquireTknVal, releaseTknVal,
-                          srcBuf, srcOffset, srcLen, DMAChan::MM2S0, rewriter);
+                          srcBuf, srcOffset, srcLen, DMAChan::MM2S, 0, rewriter);
     createDMABlocksAndOps(dstMem, tokenName, acquireTknVal, releaseTknVal,
-                          dstBuf, dstOffset, dstLen, DMAChan::S2MM0, rewriter);
+                          dstBuf, dstOffset, dstLen, DMAChan::S2MM, 0, rewriter);
 
     rewriter.eraseOp(Op);
     return success();

--- a/lib/AIELowerMemcpy.cpp
+++ b/lib/AIELowerMemcpy.cpp
@@ -49,7 +49,7 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     Block *bdBlock = rewriter.createBlock(&endBlock);
 
     rewriter.setInsertionPointToStart(dmaBlock);
-    rewriter.create<DMAStartOp>(rewriter.getUnknownLoc(), dmaDir, channelIndex, 
+    rewriter.create<DMAStartOp>(rewriter.getUnknownLoc(), dmaDir, channelIndex,
                                 bdBlock, &endBlock);
 
     // Setup bd Block
@@ -84,9 +84,11 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     MemOp dstMem = dstTileOp(op).getMemOp();
 
     createDMABlocksAndOps(srcMem, tokenName, acquireTknVal, releaseTknVal,
-                          srcBuf, srcOffset, srcLen, DMAChannelDir::MM2S, 0, rewriter);
+                          srcBuf, srcOffset, srcLen, DMAChannelDir::MM2S, 0,
+                          rewriter);
     createDMABlocksAndOps(dstMem, tokenName, acquireTknVal, releaseTknVal,
-                          dstBuf, dstOffset, dstLen, DMAChannelDir::S2MM, 0, rewriter);
+                          dstBuf, dstOffset, dstLen, DMAChannelDir::S2MM, 0,
+                          rewriter);
 
     rewriter.eraseOp(Op);
     return success();

--- a/lib/AIENetlistAnalysis.cpp
+++ b/lib/AIENetlistAnalysis.cpp
@@ -397,8 +397,7 @@ void xilinx::AIE::NetlistAnalysis::dmaAnalysis() {
         Operation *destMemOp = mems[destSwbox.getTile().getDefiningOp()];
         xilinx::AIE::DMAChannel dmaChan =
             std::make_pair(DMAChannelDir::S2MM, destConnect.destIndex());
-        Operation *destDmaOp =
-            dmas[std::make_pair(destMemOp, dmaChan)];
+        Operation *destDmaOp = dmas[std::make_pair(destMemOp, dmaChan)];
         dmaConnections[srcDma].push_back(destDmaOp);
         dma2ConnectsMap[destDmaOp].push_back(destConnect);
       }

--- a/lib/AIENetlistAnalysis.cpp
+++ b/lib/AIENetlistAnalysis.cpp
@@ -221,7 +221,7 @@ void xilinx::AIE::NetlistAnalysis::collectDMAUsage() {
     for (auto op : r.getOps<cf::CondBranchOp>()) {
       DMAStartOp dmaSt =
           dyn_cast<DMAStartOp>(op.getCondition().getDefiningOp());
-      int channelNum = dmaSt.getChannelNum();
+      int channelNum = dmaSt.channelIndex();
       dmas[std::make_pair(mem, channelNum)] = dmaSt;
       Block *firstBd = op.getTrueDest();
       Block *curBd = firstBd;
@@ -374,7 +374,7 @@ void xilinx::AIE::NetlistAnalysis::dmaAnalysis() {
     if (srcDma.isRecv())
       continue;
 
-    int srcChannelIndex = srcDma.getSendChannelIndex();
+    int srcChannelIndex = srcDma.channelIndex();
 
     Operation *srcMemOp = srcDmaOp->getParentOp();
     MemOp srcMem = dyn_cast<MemOp>(srcMemOp);

--- a/lib/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/AIEObjectFifoStatefulTransform.cpp
@@ -159,8 +159,8 @@ struct AIEObjectFifoStatefulTransformPass
 
   /// Function used to create a MemOp region with a DMA channel.
   /// It uses creatBdBlock(), see there for lockMode input.
-  void createDMA(OpBuilder &builder, ObjectFifoCreateOp op, DMAChan channelMode,
-                 int lockMode) {
+  void createDMA(OpBuilder &builder, ObjectFifoCreateOp op, DMAChan channelDir,
+                 int channelIndex, int lockMode) {
     int numBlocks = op.size();
 
     if (numBlocks == 0)
@@ -185,8 +185,8 @@ struct AIEObjectFifoStatefulTransformPass
 
     // create DMA channel
     builder.setInsertionPointToStart(dmaBlock);
-    builder.create<DMAStartOp>(builder.getUnknownLoc(), channelMode, bdBlock,
-                               &endBlock);
+    builder.create<DMAStartOp>(builder.getUnknownLoc(), channelDir, channelIndex, 
+                               bdBlock, &endBlock);
 
     // create Bd blocks
     Block *succ;
@@ -616,8 +616,8 @@ struct AIEObjectFifoStatefulTransformPass
                              WireBundle::DMA, 1);
 
       // create MemOps and DMA channels
-      createDMA(builder, childProducerFifo, DMAChan::MM2S0, 0);
-      createDMA(builder, childConsumerFifo, DMAChan::S2MM1, 1);
+      createDMA(builder, childProducerFifo, DMAChan::MM2S, 0, 0);
+      createDMA(builder, childConsumerFifo, DMAChan::S2MM, 1, 1);
     }
 
     //===----------------------------------------------------------------------===//

--- a/lib/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/AIEObjectFifoStatefulTransform.cpp
@@ -159,7 +159,7 @@ struct AIEObjectFifoStatefulTransformPass
 
   /// Function used to create a MemOp region with a DMA channel.
   /// It uses creatBdBlock(), see there for lockMode input.
-  void createDMA(OpBuilder &builder, ObjectFifoCreateOp op, DMAChan channelDir,
+  void createDMA(OpBuilder &builder, ObjectFifoCreateOp op, DMAChannelDir channelDir,
                  int channelIndex, int lockMode) {
     int numBlocks = op.size();
 
@@ -616,8 +616,8 @@ struct AIEObjectFifoStatefulTransformPass
                              WireBundle::DMA, 1);
 
       // create MemOps and DMA channels
-      createDMA(builder, childProducerFifo, DMAChan::MM2S, 0, 0);
-      createDMA(builder, childConsumerFifo, DMAChan::S2MM, 1, 1);
+      createDMA(builder, childProducerFifo, DMAChannelDir::MM2S, 0, 0);
+      createDMA(builder, childConsumerFifo, DMAChannelDir::S2MM, 1, 1);
     }
 
     //===----------------------------------------------------------------------===//

--- a/lib/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/AIEObjectFifoStatefulTransform.cpp
@@ -159,8 +159,8 @@ struct AIEObjectFifoStatefulTransformPass
 
   /// Function used to create a MemOp region with a DMA channel.
   /// It uses creatBdBlock(), see there for lockMode input.
-  void createDMA(OpBuilder &builder, ObjectFifoCreateOp op, DMAChannelDir channelDir,
-                 int channelIndex, int lockMode) {
+  void createDMA(OpBuilder &builder, ObjectFifoCreateOp op,
+                 DMAChannelDir channelDir, int channelIndex, int lockMode) {
     int numBlocks = op.size();
 
     if (numBlocks == 0)
@@ -185,8 +185,8 @@ struct AIEObjectFifoStatefulTransformPass
 
     // create DMA channel
     builder.setInsertionPointToStart(dmaBlock);
-    builder.create<DMAStartOp>(builder.getUnknownLoc(), channelDir, channelIndex, 
-                               bdBlock, &endBlock);
+    builder.create<DMAStartOp>(builder.getUnknownLoc(), channelDir,
+                               channelIndex, bdBlock, &endBlock);
 
     // create Bd blocks
     Block *succ;

--- a/lib/Targets/AIETargetXAIEV1.cpp
+++ b/lib/Targets/AIETargetXAIEV1.cpp
@@ -354,11 +354,13 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
         output << "XAieDma_TileSetStartBd("
                << "(" << tileDMAInstStr(col, row) << ")"
                << ", "
-               << "XAIEDMA_TILE_CHNUM_" << stringifyDMAChan(op.dmaChan())
+               << "XAIEDMA_TILE_CHNUM_" << stringifyDMAChannelDir(op.channelDir()) 
+               << op.channelIndex()
                << ", "
                << " /* bd */ " << bdNum << ");\n";
         output << "XAieDma_TileChControl(" << tileDMAInstStr(col, row) << ", "
-               << "XAIEDMA_TILE_CHNUM_" << stringifyDMAChan(op.dmaChan())
+               << "XAIEDMA_TILE_CHNUM_" << stringifyDMAChannelDir(op.channelDir())
+               << op.channelIndex()
                << ", " << resetDisable << ", " << enable << ");\n";
       }
     }
@@ -513,13 +515,15 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
         int bdNum = blockMap[op.dest()];
 
         output << "XAieDma_ShimSetStartBd(&" << dmaName << ", "
-               << "XAIEDMA_SHIM_CHNUM_" << stringifyDMAChan(op.dmaChan())
+               << "XAIEDMA_SHIM_CHNUM_" << stringifyDMAChannelDir(op.channelDir())
+               << op.channelIndex()
                << ", "
                << " /* bd */ " << bdNum << ");\n";
         // #define XAieDma_ShimChControl(DmaInstPtr, ChNum, PauseStrm,
         // PauseMm, Enable)
         output << "XAieDma_ShimChControl(&" << dmaName << ", "
-               << "XAIEDMA_TILE_CHNUM_" << stringifyDMAChan(op.dmaChan())
+               << "XAIEDMA_TILE_CHNUM_" << stringifyDMAChannelDir(op.channelDir())
+               << op.channelIndex()
                << ", /* PauseStream */ " << disable << ", /* PauseMM */ "
                << disable << ", /* Enable */ " << enable << ");\n";
       }

--- a/lib/Targets/AIETargetXAIEV1.cpp
+++ b/lib/Targets/AIETargetXAIEV1.cpp
@@ -355,13 +355,14 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
                << "(" << tileDMAInstStr(col, row) << ")"
                << ", "
                << "XAIEDMA_TILE_CHNUM_"
-               << stringifyDMAChannelDir(op.getChannelDir()) << op.getChannelIndex()
-               << ", "
+               << stringifyDMAChannelDir(op.getChannelDir())
+               << op.getChannelIndex() << ", "
                << " /* bd */ " << bdNum << ");\n";
         output << "XAieDma_TileChControl(" << tileDMAInstStr(col, row) << ", "
                << "XAIEDMA_TILE_CHNUM_"
-               << stringifyDMAChannelDir(op.getChannelDir()) << op.getChannelIndex()
-               << ", " << resetDisable << ", " << enable << ");\n";
+               << stringifyDMAChannelDir(op.getChannelDir())
+               << op.getChannelIndex() << ", " << resetDisable << ", " << enable
+               << ");\n";
       }
     }
   }
@@ -516,16 +517,17 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
 
         output << "XAieDma_ShimSetStartBd(&" << dmaName << ", "
                << "XAIEDMA_SHIM_CHNUM_"
-               << stringifyDMAChannelDir(op.getChannelDir()) << op.getChannelIndex()
-               << ", "
+               << stringifyDMAChannelDir(op.getChannelDir())
+               << op.getChannelIndex() << ", "
                << " /* bd */ " << bdNum << ");\n";
         // #define XAieDma_ShimChControl(DmaInstPtr, ChNum, PauseStrm,
         // PauseMm, Enable)
         output << "XAieDma_ShimChControl(&" << dmaName << ", "
                << "XAIEDMA_TILE_CHNUM_"
-               << stringifyDMAChannelDir(op.getChannelDir()) << op.getChannelIndex()
-               << ", /* PauseStream */ " << disable << ", /* PauseMM */ "
-               << disable << ", /* Enable */ " << enable << ");\n";
+               << stringifyDMAChannelDir(op.getChannelDir())
+               << op.getChannelIndex() << ", /* PauseStream */ " << disable
+               << ", /* PauseMM */ " << disable << ", /* Enable */ " << enable
+               << ");\n";
       }
     }
   }

--- a/lib/Targets/AIETargetXAIEV1.cpp
+++ b/lib/Targets/AIETargetXAIEV1.cpp
@@ -354,13 +354,13 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
         output << "XAieDma_TileSetStartBd("
                << "(" << tileDMAInstStr(col, row) << ")"
                << ", "
-               << "XAIEDMA_TILE_CHNUM_" << stringifyDMAChannelDir(op.channelDir()) 
-               << op.channelIndex()
+               << "XAIEDMA_TILE_CHNUM_"
+               << stringifyDMAChannelDir(op.channelDir()) << op.channelIndex()
                << ", "
                << " /* bd */ " << bdNum << ");\n";
         output << "XAieDma_TileChControl(" << tileDMAInstStr(col, row) << ", "
-               << "XAIEDMA_TILE_CHNUM_" << stringifyDMAChannelDir(op.channelDir())
-               << op.channelIndex()
+               << "XAIEDMA_TILE_CHNUM_"
+               << stringifyDMAChannelDir(op.channelDir()) << op.channelIndex()
                << ", " << resetDisable << ", " << enable << ");\n";
       }
     }
@@ -515,15 +515,15 @@ mlir::LogicalResult AIETranslateToXAIEV1(ModuleOp module, raw_ostream &output) {
         int bdNum = blockMap[op.dest()];
 
         output << "XAieDma_ShimSetStartBd(&" << dmaName << ", "
-               << "XAIEDMA_SHIM_CHNUM_" << stringifyDMAChannelDir(op.channelDir())
-               << op.channelIndex()
+               << "XAIEDMA_SHIM_CHNUM_"
+               << stringifyDMAChannelDir(op.channelDir()) << op.channelIndex()
                << ", "
                << " /* bd */ " << bdNum << ");\n";
         // #define XAieDma_ShimChControl(DmaInstPtr, ChNum, PauseStrm,
         // PauseMm, Enable)
         output << "XAieDma_ShimChControl(&" << dmaName << ", "
-               << "XAIEDMA_TILE_CHNUM_" << stringifyDMAChannelDir(op.channelDir())
-               << op.channelIndex()
+               << "XAIEDMA_TILE_CHNUM_"
+               << stringifyDMAChannelDir(op.channelDir()) << op.channelIndex()
                << ", /* PauseStream */ " << disable << ", /* PauseMM */ "
                << disable << ", /* Enable */ " << enable << ");\n";
       }

--- a/lib/Targets/AIETargetXAIEV2.cpp
+++ b/lib/Targets/AIETargetXAIEV2.cpp
@@ -338,9 +338,8 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
       for (auto op : block.getOps<DMAStartOp>()) {
         int bdNum = blockMap[op.dest()];
 
-        llvm::StringRef dmaChan = stringifyDMAChan(op.dmaChan());
-        llvm::StringRef dmaDir = dmaChan.substr(0, 4);
-        llvm::StringRef chNum = dmaChan.substr(4, 1);
+        llvm::StringRef dmaDir = stringifyDMAChannelDir(op.channelDir());
+        int chNum = op.channelIndex();
 
         output << "XAie_DmaChannelPushBdToQueue(" << deviceInstRef << ", "
                << tileLocStr(col, row) << ", "
@@ -507,9 +506,8 @@ mlir::LogicalResult AIETranslateToXAIEV2(ModuleOp module, raw_ostream &output) {
       for (auto op : block.getOps<DMAStartOp>()) {
         int bdNum = blockMap[op.dest()];
 
-        llvm::StringRef dmaChan = stringifyDMAChan(op.dmaChan());
-        llvm::StringRef dmaDir = dmaChan.substr(0, 4);
-        llvm::StringRef chNum = dmaChan.substr(4, 1);
+        llvm::StringRef dmaDir = stringifyDMAChannelDir(op.channelDir());
+        int chNum = op.channelIndex();
 
         output << "XAie_DmaChannelPushBdToQueue(" << deviceInstRef << ", "
                << tileLocStr(col, row) << ", "

--- a/test/create-cores/duplicate_dma.mlir
+++ b/test/create-cores/duplicate_dma.mlir
@@ -15,14 +15,14 @@ module @duplicate_dma  {
   %0 = AIE.tile(1, 1)
   %1 = AIE.buffer(%0) : memref<256xi32>
   %2 = AIE.mem(%0)  {
-    %15 = AIE.dmaStart(MM2S0, ^bb1, ^bb4)
+    %15 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb4)
   ^bb1:  // pred: ^bb0
     AIE.useToken @token0(Acquire, 1)
     AIE.dmaBd(<%1 : memref<256xi32>, 0, 256>, 0)
     AIE.useToken @token0(Release, 2)
     cf.br ^bb2
   ^bb2:  
-    %16 = AIE.dmaStart(MM2S0, ^bb3, ^bb4)
+    %16 = AIE.dmaStart(MM2S, 0, ^bb3, ^bb4)
   ^bb3:  
     AIE.useToken @token1(Acquire, 1)
     AIE.dmaBd(<%1 : memref<256xi32>, 0, 256>, 0)

--- a/test/create-cores/hello_world.mlir
+++ b/test/create-cores/hello_world.mlir
@@ -14,7 +14,7 @@
 // CHECK:   %0 = AIE.tile(3, 3)
 // CHECK:   %1 = AIE.buffer(%0) : memref<512xi32>
 // CHECK:   %2 = AIE.mem(%0) {
-// CHECK:     %10 = AIE.dmaStart(MM2S0, ^bb1, ^bb2)
+// CHECK:     %10 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:   ^bb1:
 // CHECK:     AIE.useToken @token0(Acquire, 1)
 // CHECK:     AIE.dmaBd(<%1 : memref<512xi32>, 0, 512>, 0)
@@ -26,7 +26,7 @@
 // CHECK:   %3 = AIE.tile(4, 4)
 // CHECK:   %4 = AIE.buffer(%3) : memref<512xi32>
 // CHECK:   %5 = AIE.mem(%3) {
-// CHECK:     %10 = AIE.dmaStart(S2MM0, ^bb1, ^bb2)
+// CHECK:     %10 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   ^bb1:
 // CHECK:     AIE.useToken @token0(Acquire, 1)
 // CHECK:     AIE.dmaBd(<%4 : memref<512xi32>, 0, 512>, 0)

--- a/test/create-cores/test_dma0.mlir
+++ b/test/create-cores/test_dma0.mlir
@@ -14,7 +14,7 @@
 // CHECK-NEXT:    %0 = AIE.tile(1, 1)
 // CHECK-NEXT:    %1 = AIE.buffer(%0) : memref<256xi32>
 // CHECK-NEXT:    %2 = AIE.mem(%0) {
-// CHECK-NEXT:      %10 = AIE.dmaStart(MM2S0, ^bb1, ^bb2)
+// CHECK-NEXT:      %10 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK-NEXT:      ^bb1:
 // CHECK-NEXT:        AIE.useToken @token0(Acquire, 1)
 // CHECK-NEXT:        AIE.dmaBd(<%1 : memref<256xi32>, 0, 256>, 0)
@@ -26,7 +26,7 @@
 // CHECK-NEXT:    %3 = AIE.tile(2, 2)
 // CHECK-NEXT:    %4 = AIE.buffer(%3) : memref<256xi32>
 // CHECK-NEXT:    %5 = AIE.mem(%3) {
-// CHECK-NEXT:      %10 = AIE.dmaStart(S2MM0, ^bb1, ^bb2)
+// CHECK-NEXT:      %10 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK-NEXT:      ^bb1:
 // CHECK-NEXT:        AIE.useToken @token0(Acquire, 1)
 // CHECK-NEXT:        AIE.dmaBd(<%4 : memref<256xi32>, 0, 256>, 0)

--- a/test/create-cores/test_dma1.mlir
+++ b/test/create-cores/test_dma1.mlir
@@ -16,14 +16,14 @@
 // CHECK-NEXT:    %0 = AIE.tile(1, 1)
 // CHECK-NEXT:    %1 = AIE.buffer(%0) : memref<256xi32>
 // CHECK-NEXT:    %2 = AIE.mem(%0) {
-// CHECK-NEXT:      %15 = AIE.dmaStart(MM2S0, ^bb1, ^bb4)
+// CHECK-NEXT:      %15 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb4)
 // CHECK-NEXT:      ^bb1:
 // CHECK-NEXT:        AIE.useToken @token0(Acquire, 1)
 // CHECK-NEXT:        AIE.dmaBd(<%1 : memref<256xi32>, 0, 256>, 0)
 // CHECK-NEXT:        AIE.useToken @token0(Release, 2)
 // CHECK-NEXT:        cf.br ^bb4
 // CHECK-NEXT:      ^bb2:
-// CHECK-NEXT:      %16 = AIE.dmaStart(MM2S0, ^bb3, ^bb4)
+// CHECK-NEXT:      %16 = AIE.dmaStart(MM2S, 0, ^bb3, ^bb4)
 // CHECK-NEXT:      ^bb3:
 // CHECK-NEXT:        AIE.useToken @token1(Acquire, 1)
 // CHECK-NEXT:        AIE.dmaBd(<%1 : memref<256xi32>, 0, 256>, 0)
@@ -35,7 +35,7 @@
 // CHECK-NEXT:    %3 = AIE.tile(2, 2)
 // CHECK-NEXT:    %4 = AIE.buffer(%3) : memref<256xi32>
 // CHECK-NEXT:    %5 = AIE.mem(%3) {
-// CHECK-NEXT:        %15 = AIE.dmaStart(S2MM0, ^bb1, ^bb2)
+// CHECK-NEXT:        %15 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK-NEXT:      ^bb1:
 // CHECK-NEXT:        AIE.useToken @token0(Acquire, 1)
 // CHECK-NEXT:        AIE.dmaBd(<%4 : memref<256xi32>, 0, 256>, 0)
@@ -47,7 +47,7 @@
 // CHECK-NEXT:    %6 = AIE.tile(3, 3)
 // CHECK-NEXT:    %7 = AIE.buffer(%6) : memref<256xi32>
 // CHECK-NEXT:    %8 = AIE.mem(%6) {
-// CHECK-NEXT:      %15 = AIE.dmaStart(S2MM0, ^bb1, ^bb2)
+// CHECK-NEXT:      %15 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK-NEXT:      ^bb1:
 // CHECK-NEXT:        AIE.useToken @token1(Acquire, 1)
 // CHECK-NEXT:        AIE.dmaBd(<%7 : memref<256xi32>, 0, 256>, 0)

--- a/test/create-cores/test_dma2.mlir
+++ b/test/create-cores/test_dma2.mlir
@@ -15,7 +15,7 @@
 // CHECK-NEXT:  %0 = AIE.tile(1, 1)
 // CHECK-NEXT:  %1 = AIE.buffer(%0) : memref<256xi32>
 // CHECK-NEXT:  %2 = AIE.mem(%0) {
-// CHECK-NEXT:    %17 = AIE.dmaStart(MM2S0)
+// CHECK-NEXT:    %17 = AIE.dmaStart(MM2S, 0)
 // CHECK-NEXT:    AIE.terminator(^bb3, ^bb1)
 // CHECK-NEXT:  ^bb1:  // pred: ^bb0
 // CHECK-NEXT:    cond_br %17, ^bb2, ^bb3
@@ -30,7 +30,7 @@
 // CHECK-NEXT:  %3 = AIE.tile(2, 2)
 // CHECK-NEXT:  %4 = AIE.buffer(%3) : memref<256xi32>
 // CHECK-NEXT:  %5 = AIE.mem(%3) {
-// CHECK-NEXT:    %17 = AIE.dmaStart(MM2S0)
+// CHECK-NEXT:    %17 = AIE.dmaStart(MM2S, 0)
 // CHECK-NEXT:    AIE.terminator(^bb3, ^bb1)
 // CHECK-NEXT:  ^bb1:  // pred: ^bb0
 // CHECK-NEXT:    cond_br %17, ^bb2, ^bb3
@@ -46,8 +46,8 @@
 // CHECK-NEXT:  %7 = AIE.buffer(%6) : memref<256xi32>
 // CHECK-NEXT:  %8 = AIE.buffer(%6) : memref<256xi32>
 // CHECK-NEXT:  %9 = AIE.mem(%6) {
-// CHECK-NEXT:    %17 = AIE.dmaStart(S2MM0)
-// CHECK-NEXT:    %18 = AIE.dmaStart(S2MM0)
+// CHECK-NEXT:    %17 = AIE.dmaStart(S2MM, 0)
+// CHECK-NEXT:    %18 = AIE.dmaStart(S2MM, 0)
 // CHECK-NEXT:    AIE.terminator(^bb5, ^bb1, ^bb3)
 // CHECK-NEXT:  ^bb1:  // pred: ^bb0
 // CHECK-NEXT:    cond_br %17, ^bb2, ^bb5

--- a/test/create-cores/test_dma3.mlir
+++ b/test/create-cores/test_dma3.mlir
@@ -15,7 +15,7 @@
 // CHECK-NEXT:  %0 = AIE.tile(1, 1)
 // CHECK-NEXT:  %1 = AIE.buffer(%0) : memref<256xi32>
 // CHECK-NEXT:  %2 = AIE.mem(%0) {
-// CHECK-NEXT:    %15 = AIE.dmaStart(MM2S0)
+// CHECK-NEXT:    %15 = AIE.dmaStart(MM2S, 0)
 // CHECK-NEXT:    AIE.terminator(^bb3, ^bb1)
 // CHECK-NEXT:  ^bb1:  // pred: ^bb0
 // CHECK-NEXT:    cond_br %15, ^bb2, ^bb3
@@ -30,8 +30,8 @@
 // CHECK-NEXT:  %3 = AIE.tile(2, 2)
 // CHECK-NEXT:  %4 = AIE.buffer(%3) : memref<256xi32>
 // CHECK-NEXT:  %5 = AIE.mem(%3) {
-// CHECK-NEXT:    %15 = AIE.dmaStart(S2MM0)
-// CHECK-NEXT:    %16 = AIE.dmaStart(MM2S0)
+// CHECK-NEXT:    %15 = AIE.dmaStart(S2MM, 0)
+// CHECK-NEXT:    %16 = AIE.dmaStart(MM2S, 0)
 // CHECK-NEXT:    AIE.terminator(^bb5, ^bb1, ^bb3)
 // CHECK-NEXT:  ^bb1:  // pred: ^bb0
 // CHECK-NEXT:    cond_br %15, ^bb2, ^bb5
@@ -53,7 +53,7 @@
 // CHECK-NEXT:  %6 = AIE.tile(3, 3)
 // CHECK-NEXT:  %7 = AIE.buffer(%6) : memref<256xi32>
 // CHECK-NEXT:  %8 = AIE.mem(%6) {
-// CHECK-NEXT:    %15 = AIE.dmaStart(S2MM0)
+// CHECK-NEXT:    %15 = AIE.dmaStart(S2MM, 0)
 // CHECK-NEXT:    AIE.terminator(^bb3, ^bb1)
 // CHECK-NEXT:  ^bb1:  // pred: ^bb0
 // CHECK-NEXT:    cond_br %15, ^bb2, ^bb3

--- a/test/create-flows/mmult.mlir
+++ b/test/create-flows/mmult.mlir
@@ -46,7 +46,7 @@ module @aie.herd_0  {
   %9 = AIE.lock(%3, 0)
   %10 = AIE.buffer(%3) {sym_name = "buf9"} : memref<16x16xf32, 2>
   %11 = AIE.mem(%3)  {
-    %63 = AIE.dmaStart(S2MM0, ^bb1, ^bb5)
+    %63 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb5)
   ^bb1:  // 2 preds: ^bb0, ^bb2
     AIE.useLock(%9, Acquire, 0)
     AIE.dmaBd(<%10 : memref<16x16xf32, 2>, 0, 256>, 0)
@@ -58,14 +58,14 @@ module @aie.herd_0  {
     AIE.useLock(%4, Release, 1)
     cf.br ^bb1
   ^bb3:  // pred: ^bb5
-    %64 = AIE.dmaStart(S2MM1, ^bb4, ^bb7)
+    %64 = AIE.dmaStart(S2MM, 1, ^bb4, ^bb7)
   ^bb4:  // 2 preds: ^bb3, ^bb4
     AIE.useLock(%7, Acquire, 0)
     AIE.dmaBd(<%8 : memref<16x16xf32, 2>, 0, 256>, 0)
     AIE.useLock(%7, Release, 1)
     cf.br ^bb4
   ^bb5:  // pred: ^bb0
-    %65 = AIE.dmaStart(MM2S0, ^bb6, ^bb3)
+    %65 = AIE.dmaStart(MM2S, 0, ^bb6, ^bb3)
   ^bb6:  // 2 preds: ^bb5, ^bb6
     AIE.useLock(%5, Acquire, 1)
     AIE.dmaBd(<%6 : memref<16x16xf32, 2>, 0, 256>, 0)
@@ -87,7 +87,7 @@ module @aie.herd_0  {
   %23 = AIE.lock(%17, 0)
   %24 = AIE.buffer(%17) {sym_name = "buf6"} : memref<16x16xf32, 2>
   %25 = AIE.mem(%17)  {
-    %63 = AIE.dmaStart(S2MM0, ^bb1, ^bb5)
+    %63 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb5)
   ^bb1:  // 2 preds: ^bb0, ^bb2
     AIE.useLock(%23, Acquire, 0)
     AIE.dmaBd(<%24 : memref<16x16xf32, 2>, 0, 256>, 0)
@@ -99,14 +99,14 @@ module @aie.herd_0  {
     AIE.useLock(%18, Release, 1)
     cf.br ^bb1
   ^bb3:  // pred: ^bb5
-    %64 = AIE.dmaStart(S2MM1, ^bb4, ^bb7)
+    %64 = AIE.dmaStart(S2MM, 1, ^bb4, ^bb7)
   ^bb4:  // 2 preds: ^bb3, ^bb4
     AIE.useLock(%21, Acquire, 0)
     AIE.dmaBd(<%22 : memref<16x16xf32, 2>, 0, 256>, 0)
     AIE.useLock(%21, Release, 1)
     cf.br ^bb4
   ^bb5:  // pred: ^bb0
-    %65 = AIE.dmaStart(MM2S0, ^bb6, ^bb3)
+    %65 = AIE.dmaStart(MM2S, 0, ^bb6, ^bb3)
   ^bb6:  // 2 preds: ^bb5, ^bb6
     AIE.useLock(%19, Acquire, 1)
     AIE.dmaBd(<%20 : memref<16x16xf32, 2>, 0, 256>, 0)
@@ -128,7 +128,7 @@ module @aie.herd_0  {
   %37 = AIE.lock(%31, 0)
   %38 = AIE.buffer(%31) {sym_name = "buf3"} : memref<16x16xf32, 2>
   %39 = AIE.mem(%31)  {
-    %63 = AIE.dmaStart(S2MM0, ^bb1, ^bb5)
+    %63 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb5)
   ^bb1:  // 2 preds: ^bb0, ^bb2
     AIE.useLock(%37, Acquire, 0)
     AIE.dmaBd(<%38 : memref<16x16xf32, 2>, 0, 256>, 0)
@@ -140,14 +140,14 @@ module @aie.herd_0  {
     AIE.useLock(%32, Release, 1)
     cf.br ^bb1
   ^bb3:  // pred: ^bb5
-    %64 = AIE.dmaStart(S2MM1, ^bb4, ^bb7)
+    %64 = AIE.dmaStart(S2MM, 1, ^bb4, ^bb7)
   ^bb4:  // 2 preds: ^bb3, ^bb4
     AIE.useLock(%35, Acquire, 0)
     AIE.dmaBd(<%36 : memref<16x16xf32, 2>, 0, 256>, 0)
     AIE.useLock(%35, Release, 1)
     cf.br ^bb4
   ^bb5:  // pred: ^bb0
-    %65 = AIE.dmaStart(MM2S0, ^bb6, ^bb3)
+    %65 = AIE.dmaStart(MM2S, 0, ^bb6, ^bb3)
   ^bb6:  // 2 preds: ^bb5, ^bb6
     AIE.useLock(%33, Acquire, 1)
     AIE.dmaBd(<%34 : memref<16x16xf32, 2>, 0, 256>, 0)
@@ -169,7 +169,7 @@ module @aie.herd_0  {
   %51 = AIE.lock(%45, 0)
   %52 = AIE.buffer(%45) {sym_name = "buf0"} : memref<16x16xf32, 2>
   %53 = AIE.mem(%45)  {
-    %63 = AIE.dmaStart(S2MM0, ^bb1, ^bb5)
+    %63 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb5)
   ^bb1:  // 2 preds: ^bb0, ^bb2
     AIE.useLock(%51, Acquire, 0)
     AIE.dmaBd(<%52 : memref<16x16xf32, 2>, 0, 256>, 0)
@@ -181,14 +181,14 @@ module @aie.herd_0  {
     AIE.useLock(%46, Release, 1)
     cf.br ^bb1
   ^bb3:  // pred: ^bb5
-    %64 = AIE.dmaStart(S2MM1, ^bb4, ^bb7)
+    %64 = AIE.dmaStart(S2MM, 1, ^bb4, ^bb7)
   ^bb4:  // 2 preds: ^bb3, ^bb4
     AIE.useLock(%49, Acquire, 0)
     AIE.dmaBd(<%50 : memref<16x16xf32, 2>, 0, 256>, 0)
     AIE.useLock(%49, Release, 1)
     cf.br ^bb4
   ^bb5:  // pred: ^bb0
-    %65 = AIE.dmaStart(MM2S0, ^bb6, ^bb3)
+    %65 = AIE.dmaStart(MM2S, 0, ^bb6, ^bb3)
   ^bb6:  // 2 preds: ^bb5, ^bb6
     AIE.useLock(%47, Acquire, 1)
     AIE.dmaBd(<%48 : memref<16x16xf32, 2>, 0, 256>, 0)

--- a/test/create-flows/vecmul_4x4.mlir
+++ b/test/create-flows/vecmul_4x4.mlir
@@ -105,21 +105,21 @@ module @vecmul_4x4  {
   %9 = AIE.lock(%4, 0)
   %10 = AIE.buffer(%4) {sym_name = "buf45"} : memref<64xi32, 2>
   %11 = AIE.mem(%4)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%9, Acquire, 0)
     AIE.dmaBd(<%10 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%9, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%7, Acquire, 0)
     AIE.dmaBd(<%8 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%7, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%5, Acquire, 1)
     AIE.dmaBd(<%6 : memref<64xi32, 2>, 0, 64>, 0)
@@ -159,21 +159,21 @@ module @vecmul_4x4  {
   %22 = AIE.lock(%17, 0)
   %23 = AIE.buffer(%17) {sym_name = "buf42"} : memref<64xi32, 2>
   %24 = AIE.mem(%17)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%22, Acquire, 0)
     AIE.dmaBd(<%23 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%22, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%20, Acquire, 0)
     AIE.dmaBd(<%21 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%20, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%18, Acquire, 1)
     AIE.dmaBd(<%19 : memref<64xi32, 2>, 0, 64>, 0)
@@ -213,21 +213,21 @@ module @vecmul_4x4  {
   %35 = AIE.lock(%30, 0)
   %36 = AIE.buffer(%30) {sym_name = "buf39"} : memref<64xi32, 2>
   %37 = AIE.mem(%30)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%35, Acquire, 0)
     AIE.dmaBd(<%36 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%35, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%33, Acquire, 0)
     AIE.dmaBd(<%34 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%33, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%31, Acquire, 1)
     AIE.dmaBd(<%32 : memref<64xi32, 2>, 0, 64>, 0)
@@ -267,21 +267,21 @@ module @vecmul_4x4  {
   %48 = AIE.lock(%43, 0)
   %49 = AIE.buffer(%43) {sym_name = "buf36"} : memref<64xi32, 2>
   %50 = AIE.mem(%43)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%48, Acquire, 0)
     AIE.dmaBd(<%49 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%48, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%46, Acquire, 0)
     AIE.dmaBd(<%47 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%46, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%44, Acquire, 1)
     AIE.dmaBd(<%45 : memref<64xi32, 2>, 0, 64>, 0)
@@ -320,21 +320,21 @@ module @vecmul_4x4  {
   %60 = AIE.lock(%55, 0)
   %61 = AIE.buffer(%55) {sym_name = "buf33"} : memref<64xi32, 2>
   %62 = AIE.mem(%55)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%60, Acquire, 0)
     AIE.dmaBd(<%61 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%60, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%58, Acquire, 0)
     AIE.dmaBd(<%59 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%58, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%56, Acquire, 1)
     AIE.dmaBd(<%57 : memref<64xi32, 2>, 0, 64>, 0)
@@ -373,21 +373,21 @@ module @vecmul_4x4  {
   %72 = AIE.lock(%67, 0)
   %73 = AIE.buffer(%67) {sym_name = "buf30"} : memref<64xi32, 2>
   %74 = AIE.mem(%67)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%72, Acquire, 0)
     AIE.dmaBd(<%73 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%72, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%70, Acquire, 0)
     AIE.dmaBd(<%71 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%70, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%68, Acquire, 1)
     AIE.dmaBd(<%69 : memref<64xi32, 2>, 0, 64>, 0)
@@ -427,21 +427,21 @@ module @vecmul_4x4  {
   %85 = AIE.lock(%80, 0)
   %86 = AIE.buffer(%80) {sym_name = "buf27"} : memref<64xi32, 2>
   %87 = AIE.mem(%80)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%85, Acquire, 0)
     AIE.dmaBd(<%86 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%85, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%83, Acquire, 0)
     AIE.dmaBd(<%84 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%83, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%81, Acquire, 1)
     AIE.dmaBd(<%82 : memref<64xi32, 2>, 0, 64>, 0)
@@ -481,21 +481,21 @@ module @vecmul_4x4  {
   %98 = AIE.lock(%93, 0)
   %99 = AIE.buffer(%93) {sym_name = "buf24"} : memref<64xi32, 2>
   %100 = AIE.mem(%93)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%98, Acquire, 0)
     AIE.dmaBd(<%99 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%98, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%96, Acquire, 0)
     AIE.dmaBd(<%97 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%96, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%94, Acquire, 1)
     AIE.dmaBd(<%95 : memref<64xi32, 2>, 0, 64>, 0)
@@ -534,21 +534,21 @@ module @vecmul_4x4  {
   %110 = AIE.lock(%105, 0)
   %111 = AIE.buffer(%105) {sym_name = "buf21"} : memref<64xi32, 2>
   %112 = AIE.mem(%105)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%110, Acquire, 0)
     AIE.dmaBd(<%111 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%110, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%108, Acquire, 0)
     AIE.dmaBd(<%109 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%108, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%106, Acquire, 1)
     AIE.dmaBd(<%107 : memref<64xi32, 2>, 0, 64>, 0)
@@ -587,21 +587,21 @@ module @vecmul_4x4  {
   %122 = AIE.lock(%117, 0)
   %123 = AIE.buffer(%117) {sym_name = "buf18"} : memref<64xi32, 2>
   %124 = AIE.mem(%117)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%122, Acquire, 0)
     AIE.dmaBd(<%123 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%122, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%120, Acquire, 0)
     AIE.dmaBd(<%121 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%120, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%118, Acquire, 1)
     AIE.dmaBd(<%119 : memref<64xi32, 2>, 0, 64>, 0)
@@ -641,21 +641,21 @@ module @vecmul_4x4  {
   %135 = AIE.lock(%130, 0)
   %136 = AIE.buffer(%130) {sym_name = "buf15"} : memref<64xi32, 2>
   %137 = AIE.mem(%130)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%135, Acquire, 0)
     AIE.dmaBd(<%136 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%135, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%133, Acquire, 0)
     AIE.dmaBd(<%134 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%133, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%131, Acquire, 1)
     AIE.dmaBd(<%132 : memref<64xi32, 2>, 0, 64>, 0)
@@ -694,21 +694,21 @@ module @vecmul_4x4  {
   %147 = AIE.lock(%142, 0)
   %148 = AIE.buffer(%142) {sym_name = "buf12"} : memref<64xi32, 2>
   %149 = AIE.mem(%142)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%147, Acquire, 0)
     AIE.dmaBd(<%148 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%147, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%145, Acquire, 0)
     AIE.dmaBd(<%146 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%145, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%143, Acquire, 1)
     AIE.dmaBd(<%144 : memref<64xi32, 2>, 0, 64>, 0)
@@ -746,21 +746,21 @@ module @vecmul_4x4  {
   %158 = AIE.lock(%153, 0)
   %159 = AIE.buffer(%153) {sym_name = "buf9"} : memref<64xi32, 2>
   %160 = AIE.mem(%153)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%158, Acquire, 0)
     AIE.dmaBd(<%159 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%158, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%156, Acquire, 0)
     AIE.dmaBd(<%157 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%156, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%154, Acquire, 1)
     AIE.dmaBd(<%155 : memref<64xi32, 2>, 0, 64>, 0)
@@ -799,21 +799,21 @@ module @vecmul_4x4  {
   %170 = AIE.lock(%165, 0)
   %171 = AIE.buffer(%165) {sym_name = "buf6"} : memref<64xi32, 2>
   %172 = AIE.mem(%165)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%170, Acquire, 0)
     AIE.dmaBd(<%171 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%170, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%168, Acquire, 0)
     AIE.dmaBd(<%169 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%168, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%166, Acquire, 1)
     AIE.dmaBd(<%167 : memref<64xi32, 2>, 0, 64>, 0)
@@ -853,21 +853,21 @@ module @vecmul_4x4  {
   %183 = AIE.lock(%178, 0)
   %184 = AIE.buffer(%178) {sym_name = "buf3"} : memref<64xi32, 2>
   %185 = AIE.mem(%178)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%183, Acquire, 0)
     AIE.dmaBd(<%184 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%183, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%181, Acquire, 0)
     AIE.dmaBd(<%182 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%181, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%179, Acquire, 1)
     AIE.dmaBd(<%180 : memref<64xi32, 2>, 0, 64>, 0)
@@ -907,21 +907,21 @@ module @vecmul_4x4  {
   %196 = AIE.lock(%191, 0)
   %197 = AIE.buffer(%191) {sym_name = "buf0"} : memref<64xi32, 2>
   %198 = AIE.mem(%191)  {
-    %200 = AIE.dmaStart(S2MM0, ^bb1, ^bb4)
+    %200 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb4)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%196, Acquire, 0)
     AIE.dmaBd(<%197 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%196, Release, 1)
     cf.br ^bb1
   ^bb2:  // pred: ^bb4
-    %201 = AIE.dmaStart(S2MM1, ^bb3, ^bb6)
+    %201 = AIE.dmaStart(S2MM, 1, ^bb3, ^bb6)
   ^bb3:  // 2 preds: ^bb2, ^bb3
     AIE.useLock(%194, Acquire, 0)
     AIE.dmaBd(<%195 : memref<64xi32, 2>, 0, 64>, 0)
     AIE.useLock(%194, Release, 1)
     cf.br ^bb3
   ^bb4:  // pred: ^bb0
-    %202 = AIE.dmaStart(MM2S0, ^bb5, ^bb2)
+    %202 = AIE.dmaStart(MM2S, 0, ^bb5, ^bb2)
   ^bb5:  // 2 preds: ^bb4, ^bb5
     AIE.useLock(%192, Acquire, 1)
     AIE.dmaBd(<%193 : memref<64xi32, 2>, 0, 64>, 0)

--- a/test/create-locks/test_lock3.mlir
+++ b/test/create-locks/test_lock3.mlir
@@ -19,7 +19,7 @@
 // CHECK-NEXT:  %5 = AIE.buffer(%0) : memref<256xi32>
 // CHECK-NEXT:  AIE.token(0) {sym_name = "token0"}
 // CHECK-NEXT:  %6 = AIE.mem(%2) {
-// CHECK-NEXT:    %10 = AIE.dmaStart(MM2S0, ^bb1, ^bb2)
+// CHECK-NEXT:    %10 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK-NEXT:  ^bb1:
 // CHECK-NEXT:    AIE.useLock(%3, Acquire, 1)
 // CHECK-NEXT:    AIE.dmaBd(<%4 : memref<256xi32>, 0, 256>, 0)
@@ -29,7 +29,7 @@
 // CHECK-NEXT:    AIE.end
 // CHECK-NEXT:  }
 // CHECK-NEXT:  %7 = AIE.mem(%0) {
-// CHECK-NEXT:    %10 = AIE.dmaStart(S2MM0, ^bb1, ^bb2)
+// CHECK-NEXT:    %10 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK-NEXT:  ^bb1:
 // CHECK-NEXT:    AIE.useLock(%1, Acquire, 0)
 // CHECK-NEXT:    AIE.dmaBd(<%4 : memref<256xi32>, 0, 256>, 0)
@@ -64,7 +64,7 @@ module @test_lock3 {
   AIE.token(0) {sym_name = "token0"}
 
   %m33 = AIE.mem(%t33) {
-      %dmaSt = AIE.dmaStart(MM2S0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
       AIE.dmaBd(<%buf33 : memref<256xi32>, 0, 256>, 0)
@@ -75,7 +75,7 @@ module @test_lock3 {
   }
 
   %m44 = AIE.mem(%t44) {
-      %dmaSt = AIE.dmaStart(S2MM0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
       AIE.dmaBd(<%buf33 : memref<256xi32>, 0, 256>, 0)

--- a/test/create-locks/test_lock4.mlir
+++ b/test/create-locks/test_lock4.mlir
@@ -23,7 +23,7 @@
 // CHECK-NEXT:  %9 = AIE.buffer(%0) : memref<256xi32>
 // CHECK-NEXT:  AIE.token(0) {sym_name = "token0"}
 // CHECK-NEXT:  %10 = AIE.mem(%5) {
-// CHECK-NEXT:    %16 = AIE.dmaStart(MM2S0, ^bb1, ^bb2)
+// CHECK-NEXT:    %16 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK-NEXT:  ^bb1:
 // CHECK-NEXT:    AIE.useLock(%6, Acquire, 1)
 // CHECK-NEXT:    AIE.dmaBd(<%7 : memref<256xi32>, 0, 256>, 0)
@@ -33,9 +33,9 @@
 // CHECK-NEXT:    AIE.end
 // CHECK-NEXT:  }
 // CHECK-NEXT:  %11 = AIE.mem(%2) {
-// CHECK-NEXT:    %16 = AIE.dmaStart(S2MM0, ^bb2, ^bb1)
+// CHECK-NEXT:    %16 = AIE.dmaStart(S2MM, 0, ^bb2, ^bb1)
 // CHECK:       ^bb1
-// CHECK-NEXT:    %17 = AIE.dmaStart(MM2S0, ^bb3, ^bb4)
+// CHECK-NEXT:    %17 = AIE.dmaStart(MM2S, 0, ^bb3, ^bb4)
 // CHECK-NEXT:  ^bb2:
 // CHECK-NEXT:    AIE.useLock(%4, Acquire, 0)
 // CHECK-NEXT:    AIE.dmaBd(<%8 : memref<256xi32>, 0, 256>, 0)
@@ -50,7 +50,7 @@
 // CHECK-NEXT:    AIE.end
 // CHECK-NEXT:  }
 // CHECK-NEXT:  %12 = AIE.mem(%0) {
-// CHECK-NEXT:    %16 = AIE.dmaStart(S2MM0, ^bb1, ^bb2)
+// CHECK-NEXT:    %16 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK-NEXT:  ^bb1:
 // CHECK-NEXT:    AIE.useLock(%1, Acquire, 0)
 // CHECK-NEXT:    AIE.dmaBd(<%9 : memref<256xi32>, 0, 256>, 0)
@@ -94,7 +94,7 @@ module @test_lock4 {
   AIE.token(0) {sym_name = "token0"}
 
   %m33 = AIE.mem(%t33) {
-      %dmaSt = AIE.dmaStart(MM2S0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
       AIE.dmaBd(<%buf33 : memref<256xi32>, 0, 256>, 0)
@@ -105,9 +105,9 @@ module @test_lock4 {
   }
 
   %m44 = AIE.mem(%t44) {
-      %dmaSt0 = AIE.dmaStart(S2MM0, ^bd0, ^dma0)
+      %dmaSt0 = AIE.dmaStart(S2MM, 0, ^bd0, ^dma0)
     ^dma0:
-      %dmaSt1 = AIE.dmaStart(MM2S0, ^bd1, ^end)
+      %dmaSt1 = AIE.dmaStart(MM2S, 0, ^bd1, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
       AIE.dmaBd(<%buf44 : memref<256xi32>, 0, 256>, 0)
@@ -123,7 +123,7 @@ module @test_lock4 {
   }
 
   %m55 = AIE.mem(%t55) {
-    %dmaSt = AIE.dmaStart(S2MM0, ^bd0, ^end)
+    %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 3)
       AIE.dmaBd(<%buf55 : memref<256xi32>, 0, 256>, 0)

--- a/test/create-locks/test_lock5.mlir
+++ b/test/create-locks/test_lock5.mlir
@@ -77,9 +77,9 @@ module @test_lock5 {
   AIE.token(0) {sym_name = "token1"}
 
   %m33 = AIE.mem(%t33) {
-      %dmaSt0 = AIE.dmaStart(MM2S0, ^bd0, ^dma0)
+      %dmaSt0 = AIE.dmaStart(MM2S, 0, ^bd0, ^dma0)
     ^dma0:
-      %dmaSt1 = AIE.dmaStart("MM2S1", ^bd1, ^end)
+      %dmaSt1 = AIE.dmaStart("MM2S", 1, ^bd1, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
       AIE.dmaBd(<%buf33 : memref<256xi32>, 0, 256>, 0)
@@ -95,7 +95,7 @@ module @test_lock5 {
   }
 
   %m44 = AIE.mem(%t44) {
-      %dmaSt = AIE.dmaStart(S2MM0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
       AIE.dmaBd(<%buf44 : memref<256xi32>, 0, 256>, 0)
@@ -106,7 +106,7 @@ module @test_lock5 {
   }
 
   %m55 = AIE.mem(%t55) {
-      %dmaSt = AIE.dmaStart(S2MM0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token1(Acquire, 1)
       AIE.dmaBd(<%buf55 : memref<256xi32>, 0, 256>, 0)

--- a/test/create-locks/test_lock6.mlir
+++ b/test/create-locks/test_lock6.mlir
@@ -86,7 +86,7 @@ module @test_lock6 {
   AIE.token(0) {sym_name = "token1"}
 
   %m33 = AIE.mem(%t33) {
-      %dmaSt = AIE.dmaStart(MM2S0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
       AIE.dmaBd(<%buf33 : memref<256xi32>, 0, 256>, 0)
@@ -97,7 +97,7 @@ module @test_lock6 {
   }
 
   %m44 = AIE.mem(%t44) {
-      %dmaSt = AIE.dmaStart(S2MM0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token1(Acquire, 1)
       AIE.dmaBd(<%buf44 : memref<256xi32>, 0, 256>, 0)
@@ -108,9 +108,9 @@ module @test_lock6 {
   }
 
   %m55 = AIE.mem(%t55) {
-      %dmaSt0 = AIE.dmaStart(S2MM0, ^bd0, ^dma0)
+      %dmaSt0 = AIE.dmaStart(S2MM, 0, ^bd0, ^dma0)
     ^dma0:
-      %dmaSt1 = AIE.dmaStart("S2MM1", ^bd1, ^end)
+      %dmaSt1 = AIE.dmaStart("S2MM", 1, ^bd1, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
       AIE.dmaBd(<%buf55_0 : memref<256xi32>, 0, 256>, 0)

--- a/test/create-locks/test_lock_shimdma.mlir
+++ b/test/create-locks/test_lock_shimdma.mlir
@@ -21,7 +21,7 @@
 // CHECK:     AIE.end
 // CHECK:   }
 // CHECK:   %4 = AIE.shimDMA(%1)  {
-// CHECK:     %10 = AIE.dmaStart(S2MM0, ^bb1, ^bb2)
+// CHECK:     %10 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb2)
 // CHECK:   ^bb1:  // pred: ^bb0
 // CHECK:     AIE.useLock(%2, Acquire, 0)
 // CHECK:     AIE.dmaBd(<%0 : memref<256xi32>, 0, 256>, 0)
@@ -39,7 +39,7 @@
 // CHECK:     AIE.end
 // CHECK:   }
 // CHECK:   %9 = AIE.mem(%5)  {
-// CHECK:     %10 = AIE.dmaStart(MM2S0, ^bb1, ^bb2)
+// CHECK:     %10 = AIE.dmaStart(MM2S, 0, ^bb1, ^bb2)
 // CHECK:   ^bb1:  // pred: ^bb0
 // CHECK:     AIE.useLock(%6, Acquire, 1)
 // CHECK:     AIE.dmaBd(<%7 : memref<256xi32>, 0, 256>, 0)
@@ -68,7 +68,7 @@ module @test_lock_shimdma {
     AIE.end
   }
   %m60 = AIE.shimDMA(%t60) {
-      %dmaSt = AIE.dmaStart(S2MM0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
       AIE.dmaBd(<%buf_ext : memref<256xi32>, 0, 256>, 0)
@@ -86,7 +86,7 @@ module @test_lock_shimdma {
     AIE.end
   }
   %m33 = AIE.mem(%t33) {
-      %dmaSt = AIE.dmaStart(MM2S0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.useToken @token0(Acquire, 1)
       AIE.dmaBd(<%buf33 : memref<256xi32>, 0, 256>, 0)

--- a/test/example0.mlir
+++ b/test/example0.mlir
@@ -44,9 +44,9 @@ module @example0 {
   %buf44 = AIE.buffer(%t44) : memref<256xi32>
 
   %m33 = AIE.mem(%t33) {
-      %dmaSt0 = AIE.dmaStart(MM2S0, ^bd0, ^dma0)
+      %dmaSt0 = AIE.dmaStart(MM2S, 0, ^bd0, ^dma0)
     ^dma0:
-      %dmaSt1 = AIE.dmaStart("MM2S1", ^bd1, ^end)
+      %dmaSt1 = AIE.dmaStart("MM2S", 1, ^bd1, ^end)
     ^bd0:
       AIE.useLock(%l33_0, Acquire, 1)
       AIE.dmaBd(<%buf33 : memref<256xi32>, 0, 256>, 0)
@@ -62,7 +62,7 @@ module @example0 {
   }
 
   %m42 = AIE.mem(%t42) {
-      %dmaSt = AIE.dmaStart(S2MM0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l42_0, Acquire, 0)
       AIE.dmaBd(<%buf42 : memref<256xi32>, 0, 256>, 0)
@@ -73,7 +73,7 @@ module @example0 {
   }
 
   %m44 = AIE.mem(%t44) {
-      %dmaSt = AIE.dmaStart(S2MM0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l44_0, Acquire, 1)
       AIE.dmaBd(<%buf44 : memref<256xi32>, 0, 256>, 0)

--- a/test/lower-to-standard/lower_dma.mlir
+++ b/test/lower-to-standard/lower_dma.mlir
@@ -37,7 +37,7 @@ module @example0 {
   %buf43 = AIE.buffer(%t43) { sym_name = "b" } : memref<256xi32>
 
   %m33 = AIE.mem(%t33) {
-      %dmaSt0 = AIE.dmaStart(MM2S0, ^bd0, ^end)
+      %dmaSt0 = AIE.dmaStart(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l33_0, Acquire, 1)
       AIE.dmaBd(<%buf33 : memref<256xi32>, 0, 256>, 0)
@@ -48,7 +48,7 @@ module @example0 {
   }
 
   %m43 = AIE.mem(%t43) {
-      %dmaSt = AIE.dmaStart(S2MM0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l43_0, Acquire, 0)
       AIE.dmaBd(<%buf43 : memref<256xi32>, 0, 256>, 0)

--- a/test/reference_designs/MM_2x2/aie.mlir
+++ b/test/reference_designs/MM_2x2/aie.mlir
@@ -87,9 +87,9 @@ module @MM_2x2 {
   
 
   %dma60 = AIE.shimDMA(%t60) {
-    AIE.dmaStart("MM2S0", ^bd4, ^dma2)
+    AIE.dmaStart("MM2S", 0, ^bd4, ^dma2)
     ^dma2:
-        AIE.dmaStart("MM2S1", ^bd6, ^end)
+        AIE.dmaStart("MM2S", 1, ^bd6, ^end)
     ^bd4:
       AIE.useLock(%lock60_0, "Acquire", 1)
       AIE.dmaBdPacket(0x0, 0x0)
@@ -122,9 +122,9 @@ module @MM_2x2 {
   %lock70_1 = AIE.lock(%t70, 1)
 
   %dma70 = AIE.shimDMA(%t70) {
-    AIE.dmaStart("MM2S0", ^bd4, ^dma2)
+    AIE.dmaStart("MM2S", 0, ^bd4, ^dma2)
     ^dma2:
-        AIE.dmaStart("S2MM0", ^bd6, ^end)
+        AIE.dmaStart("S2MM", 0, ^bd6, ^end)
     ^bd4:
       AIE.useLock(%lock70_0, "Acquire", 1)
       AIE.dmaBdPacket(0x4, 0x4)
@@ -151,9 +151,9 @@ module @MM_2x2 {
   %lock63_0 = AIE.lock(%t63, 0)
   %lock63_1 = AIE.lock(%t63, 1)
   %m63 = AIE.mem(%t63)  {
-  AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+  AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
   ^dma0:
-    AIE.dmaStart("S2MM1", ^bd1, ^end)
+    AIE.dmaStart("S2MM", 1, ^bd1, ^end)
   ^bd0: 
     AIE.useLock(%lock63_0, Acquire, 0)
     AIE.dmaBd(<%buf63_0 : memref<1024xi32>, 0, 1024>, 0)
@@ -172,9 +172,9 @@ module @MM_2x2 {
   %lock64_0 = AIE.lock(%t64, 0)
   %lock64_1 = AIE.lock(%t64, 1)
   %m64 = AIE.mem(%t64)  {
-  AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+  AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
   ^dma0:
-    AIE.dmaStart("S2MM1", ^bd1, ^dma1)
+    AIE.dmaStart("S2MM", 1, ^bd1, ^dma1)
   ^bd0: 
     AIE.useLock(%lock64_0, Acquire, 0)
     AIE.dmaBd(<%buf64_0 : memref<1024xi32>, 0, 1024>, 0)
@@ -186,7 +186,7 @@ module @MM_2x2 {
     AIE.useLock(%lock64_1, Release, 1)
     cf.br ^bd1
   ^dma1:
-    AIE.dmaStart("MM2S0", ^bd2, ^end)
+    AIE.dmaStart("MM2S", 0, ^bd2, ^end)
   ^bd2:
     AIE.useLock(%lock64_2, Acquire, 1)
     AIE.dmaBdPacket(0, 6)
@@ -233,9 +233,9 @@ module @MM_2x2 {
   %lock73_1 = AIE.lock(%t73, 1)
   
   %m73 = AIE.mem(%t73)  {
-  AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+  AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
   ^dma0:
-    AIE.dmaStart("S2MM1", ^bd1, ^end)
+    AIE.dmaStart("S2MM", 1, ^bd1, ^end)
   ^bd0: 
     AIE.useLock(%lock73_0, Acquire, 0)
     AIE.dmaBd(<%buf73_0 : memref<1024xi32>, 0, 1024>, 0)
@@ -255,9 +255,9 @@ module @MM_2x2 {
   %lock74_1 = AIE.lock(%t74, 1)
   %m74 = AIE.mem(%t74)  {
   
-  AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+  AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
   ^dma0:
-    AIE.dmaStart("S2MM1", ^bd1, ^dma1)
+    AIE.dmaStart("S2MM", 1, ^bd1, ^dma1)
   ^bd0: 
     AIE.useLock(%lock74_0, Acquire, 0)
     AIE.dmaBd(<%buf74_0 : memref<1024xi32>, 0, 1024>, 0)
@@ -269,7 +269,7 @@ module @MM_2x2 {
     AIE.useLock(%lock74_1, Release, 1)
     cf.br ^bd1
   ^dma1:
-    AIE.dmaStart("MM2S0", ^bd2, ^end)
+    AIE.dmaStart("MM2S", 0, ^bd2, ^end)
   ^bd2:
     AIE.useLock(%lock74_2, Acquire, 1)
     AIE.dmaBdPacket(0, 7)

--- a/test/reference_designs/idct/aie.mlir
+++ b/test/reference_designs/idct/aie.mlir
@@ -161,9 +161,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
 
   // Tile DMA
   %m73 = AIE.mem(%t73) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
     ^dma0:
-      %dstDma = AIE.dmaStart("MM2S1", ^bd2, ^end)
+      %dstDma = AIE.dmaStart("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.useLock(%lock_73_a_ping, "Acquire", 0)
       AIE.dmaBd(<%buf_73_aping : memref<64xi16>, 0, 64>, 0)
@@ -190,9 +190,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
 
     // Tile DMA
   %m74 = AIE.mem(%t74) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
     ^dma0:
-      %dstDma = AIE.dmaStart("MM2S1", ^bd2, ^end)
+      %dstDma = AIE.dmaStart("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.useLock(%lock_74_a_ping, "Acquire", 0)
       AIE.dmaBd(<%buf_74_aping : memref<64xi16>, 0, 64>, 0)
@@ -219,9 +219,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
 
   // Tile DMA
   %m75 = AIE.mem(%t75) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
     ^dma0:
-      %dstDma = AIE.dmaStart("MM2S1", ^bd2, ^end)
+      %dstDma = AIE.dmaStart("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.useLock(%lock_75_a_ping, "Acquire", 0)
       AIE.dmaBd(<%buf_75_aping : memref<64xi16>, 0, 64>, 0)
@@ -280,9 +280,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
   %dma = AIE.shimDMA(%t70) {
       %lock1 = AIE.lock(%t70, 1)
       %lock2 = AIE.lock(%t70, 2)
-      AIE.dmaStart(MM2S0, ^bd0, ^dma)
+      AIE.dmaStart(MM2S, 0, ^bd0, ^dma)
     ^dma:
-      AIE.dmaStart(S2MM0, ^bd1, ^end)
+      AIE.dmaStart(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.useLock(%lock1, Acquire, 1)
       AIE.dmaBd(<%buffer_in : memref<512 x i16>, 0, 512>, 0)

--- a/test/test_buffer_merge0.mlir
+++ b/test/test_buffer_merge0.mlir
@@ -74,7 +74,7 @@ module @test_buffer_merge0 {
   %buf32_0 = AIE.buffer(%t32) : memref<256xi32>
 
   %m34 = AIE.mem(%t34) {
-      %dmaSt = AIE.dmaStart(MM2S0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l34_0, Acquire, 1)
       AIE.dmaBd(<%buf34_0 : memref<256xi32>, 0, 256>, 0)
@@ -85,7 +85,7 @@ module @test_buffer_merge0 {
   }
 
   %m32 = AIE.mem(%t32) {
-      %dmaSt = AIE.dmaStart(S2MM0, ^bd0, ^end)
+      %dmaSt = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l32_0, Acquire, 0)
       AIE.dmaBd(<%buf32_0 : memref<256xi32>, 0, 256>, 0)

--- a/test/unit_tests/05_tiledma/aie.mlir
+++ b/test/unit_tests/05_tiledma/aie.mlir
@@ -63,7 +63,7 @@ module @test05_tiledma {
   }
 
   %mem13 = AIE.mem(%tile13) {
-    %dma0 = AIE.dmaStart("MM2S0", ^bd0, ^end)
+    %dma0 = AIE.dmaStart("MM2S", 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%lock13_5, "Acquire", 1)
       AIE.dmaBd(<%buf13_1 : memref<256xi32>, 0, 256>, 0)
@@ -74,7 +74,7 @@ module @test05_tiledma {
   }
 
   %mem33 = AIE.mem(%tile33) {
-    %dma0 = AIE.dmaStart("S2MM1", ^bd0, ^end)
+    %dma0 = AIE.dmaStart("S2MM", 1, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%lock33_6, "Acquire", 0)
       AIE.dmaBd(<%buf33_0: memref<256xi32>, 0, 256>, 0)

--- a/test/unit_tests/08_stream_broadcast/aie.mlir
+++ b/test/unit_tests/08_stream_broadcast/aie.mlir
@@ -57,7 +57,7 @@ module @test08_stream_broadcast {
   }
 
   %mem13 = AIE.mem(%tile13) {
-    %dma0 = AIE.dmaStart("MM2S0", ^bd0, ^end)
+    %dma0 = AIE.dmaStart("MM2S", 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%lock13_5, "Acquire", 1)
       AIE.dmaBd(<%buf13_1 : memref<256xi32>, 0, 256>, 0)
@@ -94,7 +94,7 @@ module @test08_stream_broadcast {
   }
 
   %mem32 = AIE.mem(%tile32) {
-    %dma0 = AIE.dmaStart("S2MM1", ^bd0, ^end)
+    %dma0 = AIE.dmaStart("S2MM", 1, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%lock32_6, "Acquire", 0)
       AIE.dmaBd(<%buf32_0 : memref<256xi32>, 0, 256>, 0)
@@ -129,7 +129,7 @@ module @test08_stream_broadcast {
   }
 
   %mem33 = AIE.mem(%tile33) {
-    %dma0 = AIE.dmaStart("S2MM1", ^bd0, ^end)
+    %dma0 = AIE.dmaStart("S2MM", 1, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%lock33_6, "Acquire", 0)
       AIE.dmaBd(<%buf33_0 : memref<256xi32>, 0, 256>, 0)
@@ -164,7 +164,7 @@ module @test08_stream_broadcast {
   }
 
   %mem34 = AIE.mem(%tile34) {
-    %dma0 = AIE.dmaStart("S2MM1", ^bd0, ^end)
+    %dma0 = AIE.dmaStart("S2MM", 1, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%lock34_6, "Acquire", 0)
       AIE.dmaBd(<%buf34_0 : memref<256xi32>, 0, 256>, 0)

--- a/test/unit_tests/09_simple_shim_dma/aie.mlir
+++ b/test/unit_tests/09_simple_shim_dma/aie.mlir
@@ -29,7 +29,7 @@ module @test09_simple_shim_dma {
   %dma = AIE.shimDMA(%t70) {
     %lock1 = AIE.lock(%t70, 1)
 
-      AIE.dmaStart(MM2S0, ^bd0, ^end)
+      AIE.dmaStart(MM2S, 0, ^bd0, ^end)
 
     ^bd0:
       AIE.useLock(%lock1, Acquire, 1)
@@ -49,7 +49,7 @@ module @test09_simple_shim_dma {
   %l72_1 = AIE.lock(%t72, 1)
 
   %m72 = AIE.mem(%t72) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l72_0, "Acquire", 0)
       AIE.dmaBd(<%buf72_0 : memref<256xi32>, 0, 256>, 0)

--- a/test/unit_tests/14_stream_packet/aie.mlir
+++ b/test/unit_tests/14_stream_packet/aie.mlir
@@ -49,7 +49,7 @@ module @test14_stream_packet {
   %l71 = AIE.lock(%t71, 0)
 
   %m73 = AIE.mem(%t73) {
-      %srcDma = AIE.dmaStart("MM2S0", ^bd0, ^end)
+      %srcDma = AIE.dmaStart("MM2S", 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l73, "Acquire", 0)
       AIE.dmaBdPacket(0x5, 0xD)
@@ -61,7 +61,7 @@ module @test14_stream_packet {
   }
 
   %m71 = AIE.mem(%t71) {
-      %srcDma = AIE.dmaStart("MM2S0", ^bd0, ^end)
+      %srcDma = AIE.dmaStart("MM2S", 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l71, "Acquire", 0)
       AIE.dmaBdPacket(0x4, 0xC)
@@ -80,9 +80,9 @@ module @test14_stream_packet {
   %l62 = AIE.lock(%t62, 0)
 
   %m62 = AIE.mem(%t62) {
-      %srcDma0 = AIE.dmaStart("S2MM0", ^bd0, ^end)
+      %srcDma0 = AIE.dmaStart("S2MM", 0, ^bd0, ^end)
     //^dma:
-    //  %srcDma1 = AIE.dmaStart("S2MM1", ^bd1, ^end)
+    //  %srcDma1 = AIE.dmaStart("S2MM", 1, ^bd1, ^end)
     ^bd0:
       AIE.useLock(%l62, "Acquire", 0)
       AIE.dmaBd(<%buf62 : memref<512xi32>, 0, 512>, 0)

--- a/test/unit_tests/17_shim_dma_with_core/aie.mlir
+++ b/test/unit_tests/17_shim_dma_with_core/aie.mlir
@@ -76,9 +76,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
 
   // Tile DMA
   %m73 = AIE.mem(%t73) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
     ^dma0:
-      %dstDma = AIE.dmaStart("MM2S1", ^bd2, ^end)
+      %dstDma = AIE.dmaStart("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.useLock(%lock_a_ping, "Acquire", 0)
       AIE.dmaBd(<%buf_a_ping : memref<64xi32>, 0, 64>, 0)
@@ -123,9 +123,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
   %dma = AIE.shimDMA(%t70) {
       %lock1 = AIE.lock(%t70, 1)
       %lock2 = AIE.lock(%t70, 2)
-      AIE.dmaStart(MM2S0, ^bd0, ^dma)
+      AIE.dmaStart(MM2S, 0, ^bd0, ^dma)
     ^dma:
-      AIE.dmaStart(S2MM0, ^bd1, ^end)
+      AIE.dmaStart(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.useLock(%lock1, Acquire, 1)
       AIE.dmaBd(<%buffer_in : memref<512 x i32>, 0, 512>, 0)

--- a/test/unit_tests/18_simple_shim_dma_routed/aie.mlir
+++ b/test/unit_tests/18_simple_shim_dma_routed/aie.mlir
@@ -20,7 +20,7 @@ module @test09_simple_shim_dma {
   %dma = AIE.shimDMA(%t70) {
     %lock1 = AIE.lock(%t70, 1)
 
-      AIE.dmaStart(MM2S0, ^bd0, ^end)
+      AIE.dmaStart(MM2S, 0, ^bd0, ^end)
 
     ^bd0:
       AIE.useLock(%lock1, Acquire, 1)
@@ -40,7 +40,7 @@ module @test09_simple_shim_dma {
   %l72_1 = AIE.lock(%t72, 1)
 
   %m72 = AIE.mem(%t72) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l72_0, "Acquire", 0)
       AIE.dmaBd(<%buf72_0 : memref<256xi32>, 0, 256>, 0)

--- a/test/unit_tests/19_shim_dma_with_core_routed/aie.mlir
+++ b/test/unit_tests/19_shim_dma_with_core_routed/aie.mlir
@@ -74,9 +74,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
 
   // Tile DMA
   %m73 = AIE.mem(%t73) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
     ^dma0:
-      %dstDma = AIE.dmaStart("MM2S1", ^bd2, ^end)
+      %dstDma = AIE.dmaStart("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.useLock(%lock_a_ping, "Acquire", 0)
       AIE.dmaBd(<%buf_a_ping : memref<64xi32>, 0, 64>, 0)
@@ -113,9 +113,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
   %dma = AIE.shimDMA(%t70) {
       %lock1 = AIE.lock(%t70, 1)
       %lock2 = AIE.lock(%t70, 2)
-      AIE.dmaStart(MM2S0, ^bd0, ^dma)
+      AIE.dmaStart(MM2S, 0, ^bd0, ^dma)
     ^dma:
-      AIE.dmaStart(S2MM0, ^bd1, ^end)
+      AIE.dmaStart(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.useLock(%lock1, Acquire, 1)
       AIE.dmaBd(<%buffer_in : memref<512 x i32>, 0, 512>, 0)

--- a/test/unit_tests/20_shim_dma_broadcast/aie.mlir
+++ b/test/unit_tests/20_shim_dma_broadcast/aie.mlir
@@ -21,7 +21,7 @@ module @test09_simple_shim_dma {
   %dma = AIE.shimDMA(%t70) {
     %lock1 = AIE.lock(%t70, 1)
 
-      AIE.dmaStart(MM2S0, ^bd0, ^end)
+      AIE.dmaStart(MM2S, 0, ^bd0, ^end)
 
     ^bd0:
       AIE.useLock(%lock1, Acquire, 1)
@@ -41,7 +41,7 @@ module @test09_simple_shim_dma {
   %l72_1 = AIE.lock(%t72, 1)
 
   %m72 = AIE.mem(%t72) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l72_0, "Acquire", 0)
       AIE.dmaBd(<%buf72_0 : memref<256xi32>, 0, 256>, 0)
@@ -65,7 +65,7 @@ module @test09_simple_shim_dma {
   %l73_1 = AIE.lock(%t73, 1)
 
   %m73 = AIE.mem(%t73) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^end)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l73_0, "Acquire", 0)
       AIE.dmaBd(<%buf73_0 : memref<256xi32>, 0, 256>, 0)

--- a/test/unit_tests/23_broadcast_packet/aie.mlir
+++ b/test/unit_tests/23_broadcast_packet/aie.mlir
@@ -33,7 +33,7 @@ module @test_broadcast_packet {
   %m72 = AIE.mem(%t72) {
     %lock72_4 = AIE.lock(%t72, 4)
     %lock72_5 = AIE.lock(%t72, 5)
-    AIE.dmaStart("MM2S0", ^bd4, ^end)
+    AIE.dmaStart("MM2S", 0, ^bd4, ^end)
     ^bd4:
       AIE.useLock(%lock72_4, "Acquire", 1)
       AIE.dmaBdPacket(0x0, 0x0)
@@ -52,7 +52,7 @@ module @test_broadcast_packet {
 
   %lock63_0 = AIE.lock(%t63, 0)
   %m63 = AIE.mem(%t63)  {
-  AIE.dmaStart("S2MM0", ^bd0, ^end)
+  AIE.dmaStart("S2MM", 0, ^bd0, ^end)
   ^bd0: 
     AIE.useLock(%lock63_0, Acquire, 0)
     AIE.dmaBd(<%buf63_0 : memref<1024xi32>, 0, 1024>, 0)
@@ -65,7 +65,7 @@ module @test_broadcast_packet {
 
   %lock64_0 = AIE.lock(%t64, 0)
   %m64 = AIE.mem(%t64)  {
-  AIE.dmaStart("S2MM0", ^bd0, ^end)
+  AIE.dmaStart("S2MM", 0, ^bd0, ^end)
   ^bd0: 
     AIE.useLock(%lock64_0, Acquire, 0)
     AIE.dmaBd(<%buf64_0 : memref<1024xi32>, 0, 1024>, 0)
@@ -78,7 +78,7 @@ module @test_broadcast_packet {
  
   %lock73_0 = AIE.lock(%t73, 0)
   %m73 = AIE.mem(%t73)  {
-  AIE.dmaStart("S2MM0", ^bd0, ^end)
+  AIE.dmaStart("S2MM", 0, ^bd0, ^end)
   ^bd0: 
     AIE.useLock(%lock73_0, Acquire, 0)
     AIE.dmaBd(<%buf73_0 : memref<1024xi32>, 0, 1024>, 0)
@@ -91,7 +91,7 @@ module @test_broadcast_packet {
   %lock74_0 = AIE.lock(%t74, 0)
   %m74 = AIE.mem(%t74)  {
   
-  AIE.dmaStart("S2MM0", ^bd0, ^end)
+  AIE.dmaStart("S2MM", 0, ^bd0, ^end)
   ^bd0: 
     AIE.useLock(%lock74_0, Acquire, 0)
     AIE.dmaBd(<%buf74_0 : memref<1024xi32>, 0, 1024>, 0)

--- a/test/unit_tests/23_packet_biShim/aie.mlir
+++ b/test/unit_tests/23_packet_biShim/aie.mlir
@@ -13,9 +13,9 @@ module @aie_module  {
   %buf_o = AIE.external_buffer 0x020100006000 : memref<257xi32>
 
   %12 = AIE.mem(%t72)  {
-    %srcDma = AIE.dmaStart("S2MM0", ^bb2, ^dma0)
+    %srcDma = AIE.dmaStart("S2MM", 0, ^bb2, ^dma0)
   ^dma0:
-    %dstDma = AIE.dmaStart("MM2S0", ^bb3, ^end)
+    %dstDma = AIE.dmaStart("MM2S", 0, ^bb3, ^end)
   ^bb2:
     AIE.useLock(%10, Acquire, 0)
     AIE.dmaBd(<%11 : memref<256xi32>, 0, 256>, 0)
@@ -31,9 +31,9 @@ module @aie_module  {
   }
 
   %dma = AIE.shimDMA(%t70)  {
-    AIE.dmaStart("MM2S0", ^bb2, ^dma0)
+    AIE.dmaStart("MM2S", 0, ^bb2, ^dma0)
   ^dma0:
-    AIE.dmaStart("S2MM0", ^bb3, ^end)
+    AIE.dmaStart("S2MM", 0, ^bb3, ^end)
   ^bb2:
     AIE.useLock(%lock1, Acquire, 1)
     AIE.dmaBdPacket(0x2, 3)

--- a/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/04_shim_dma_kernel/aie.mlir
@@ -33,9 +33,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
 
   // Tile DMA
   %m73 = AIE.mem(%t73) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
     ^dma0:
-      %dstDma = AIE.dmaStart("MM2S1", ^bd2, ^end)
+      %dstDma = AIE.dmaStart("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.useLock(%lock_a_ping, "Acquire", 0)
       AIE.dmaBd(<%buf_a_ping : memref<256xi32>, 0, 256>, 0)
@@ -79,11 +79,11 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
   // Shim DMA loads large buffer to local memory
   %dma = AIE.shimDMA(%t70) {
       %lock1 = AIE.lock(%t70, 1)
-//      AIE.dmaStart(MM2S0, ^bd0, ^end)
+//      AIE.dmaStart(MM2S, 0, ^bd0, ^end)
       %lock2 = AIE.lock(%t70, 2)
-      AIE.dmaStart(MM2S0, ^bd0, ^dma)
+      AIE.dmaStart(MM2S, 0, ^bd0, ^dma)
     ^dma:
-      AIE.dmaStart(S2MM0, ^bd1, ^end)
+      AIE.dmaStart(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.useLock(%lock1, Acquire, 1)
       AIE.dmaBd(<%buffer_in : memref<512 x i32>, 0, 512>, 0)

--- a/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/05_shim_dma_core_function/aie.mlir
@@ -58,9 +58,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
 
   // Tile DMA
   %m73 = AIE.mem(%t73) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
     ^dma0:
-      %dstDma = AIE.dmaStart("MM2S1", ^bd2, ^end)
+      %dstDma = AIE.dmaStart("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.useLock(%lock_a_ping, "Acquire", 0)
       AIE.dmaBd(<%buf_a_ping : memref<256xi32>, 0, 256>, 0)
@@ -104,11 +104,11 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
   // Shim DMA loads large buffer to local memory
   %dma = AIE.shimDMA(%t70) {
       %lock1 = AIE.lock(%t70, 1)
-//      AIE.dmaStart(MM2S0, ^bd0, ^end)
+//      AIE.dmaStart(MM2S, 0, ^bd0, ^end)
       %lock2 = AIE.lock(%t70, 2)
-      AIE.dmaStart(MM2S0, ^bd0, ^dma)
+      AIE.dmaStart(MM2S, 0, ^bd0, ^dma)
     ^dma:
-      AIE.dmaStart(S2MM0, ^bd1, ^end)
+      AIE.dmaStart(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.useLock(%lock1, Acquire, 1)
       AIE.dmaBd(<%buffer_in : memref<512 x i32>, 0, 512>, 0)

--- a/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
+++ b/test/unit_tests/chess_compiler_tests/07_shim_dma_core_function_with_loop/aie.mlir
@@ -64,9 +64,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
 
   // Tile DMA
   %m73 = AIE.mem(%t73) {
-      %srcDma = AIE.dmaStart("S2MM0", ^bd0, ^dma0)
+      %srcDma = AIE.dmaStart("S2MM", 0, ^bd0, ^dma0)
     ^dma0:
-      %dstDma = AIE.dmaStart("MM2S1", ^bd2, ^end)
+      %dstDma = AIE.dmaStart("MM2S", 1, ^bd2, ^end)
     ^bd0:
       AIE.useLock(%lock_a_ping, "Acquire", 0)
       AIE.dmaBd(<%buf_a_ping : memref<64xi32>, 0, 64>, 0)
@@ -111,9 +111,9 @@ module @test_chess_04_deprecated_shim_dma_precompiled_kernel{
   %dma = AIE.shimDMA(%t70) {
       %lock1 = AIE.lock(%t70, 1)
       %lock2 = AIE.lock(%t70, 2)
-      AIE.dmaStart(MM2S0, ^bd0, ^dma)
+      AIE.dmaStart(MM2S, 0, ^bd0, ^dma)
     ^dma:
-      AIE.dmaStart(S2MM0, ^bd1, ^end)
+      AIE.dmaStart(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.useLock(%lock1, Acquire, 1)
       AIE.dmaBd(<%buffer_in : memref<512 x i32>, 0, 512>, 0)

--- a/test/xaie_target/packet_drop_header.mlir
+++ b/test/xaie_target/packet_drop_header.mlir
@@ -33,9 +33,9 @@ module @aie_module  {
   %11 = AIE.buffer(%t71) {sym_name = "buf1"} : memref<16xi32, 2>
 
   %12 = AIE.mem(%t71)  {
-    %srcDma = AIE.dmaStart("S2MM0", ^bb2, ^dma0)
+    %srcDma = AIE.dmaStart("S2MM", 0, ^bb2, ^dma0)
   ^dma0:
-    %dstDma = AIE.dmaStart("MM2S0", ^bb3, ^end)
+    %dstDma = AIE.dmaStart("MM2S", 0, ^bb3, ^end)
   ^bb2:
     AIE.useLock(%10, Acquire, 0)
     AIE.dmaBdPacket(0x2, 3)

--- a/test/xaie_target/packet_shim_header.mlir
+++ b/test/xaie_target/packet_shim_header.mlir
@@ -27,7 +27,7 @@ module @aie_module  {
   %buffer = AIE.external_buffer 0x020100004000 : memref<32xi32>
 
   %12 = AIE.mem(%t71)  {
-    %srcDma = AIE.dmaStart("S2MM0", ^bb2, ^end)
+    %srcDma = AIE.dmaStart("S2MM", 0, ^bb2, ^end)
   ^bb2:
     AIE.useLock(%10, Acquire, 0)
     AIE.dmaBd(<%11 : memref<32xi32, 2>, 0, 32>, 0)
@@ -39,7 +39,7 @@ module @aie_module  {
 
   %dma = AIE.shimDMA(%t70) {
     %lock1 = AIE.lock(%t70, 1)
-      AIE.dmaStart(MM2S0, ^bd0, ^end)
+      AIE.dmaStart(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%lock1, Acquire, 1)
       AIE.dmaBdPacket(0x6, 10)

--- a/test/xaie_target/shim.mlir
+++ b/test/xaie_target/shim.mlir
@@ -70,9 +70,9 @@ module {
       %lock0 = AIE.lock(%t20, 0)
       %lock1 = AIE.lock(%t20, 1)
    
-      AIE.dmaStart(S2MM0, ^bd0, ^dma0)
+      AIE.dmaStart(S2MM, 0, ^bd0, ^dma0)
     ^dma0:
-      AIE.dmaStart(MM2S0, ^bd1, ^end)
+      AIE.dmaStart(MM2S, 0, ^bd1, ^end)
     ^bd0:
       AIE.useLock(%lock0, Acquire, 0)
       AIE.dmaBd(<%buffer : memref<16 x f32>, 0, 16>, 0)

--- a/test/xaie_target/test_error_dma_multi_lock.mlir
+++ b/test/xaie_target/test_error_dma_multi_lock.mlir
@@ -16,7 +16,7 @@ module @test_error_dma_multi_lock {
   %l33_0 = AIE.lock(%t33, 0)
   %l33_1 = AIE.lock(%t33, 1)
   AIE.mem(%t33) {
-    AIE.dmaStart(MM2S0, ^bb1, ^end)
+    AIE.dmaStart(MM2S, 0, ^bb1, ^end)
   ^bb1:
     AIE.useLock(%l33_0, Acquire, 1)
     // This should fail because only one lock can be used in a DmaBd

--- a/test/xaie_target/test_error_dma_multi_state.mlir
+++ b/test/xaie_target/test_error_dma_multi_state.mlir
@@ -15,7 +15,7 @@ module @test_error_dma_multi_state {
   %t33 = AIE.tile(3, 3)
   %l33_0 = AIE.lock(%t33, 0)
   AIE.mem(%t33) {
-    AIE.dmaStart(MM2S0, ^bb1, ^end)
+    AIE.dmaStart(MM2S, 0, ^bb1, ^end)
   ^bb1:
     AIE.useLock(%l33_0, Acquire, 0)
     // This should fail because only one state can be acquired in a DmaBd

--- a/test/xaie_target/test_error_shimdma_multi_lock.mlir
+++ b/test/xaie_target/test_error_shimdma_multi_lock.mlir
@@ -16,7 +16,7 @@ module @test_error_shimdma_multi_lock {
   %l30_0 = AIE.lock(%t30, 0)
   %l30_1 = AIE.lock(%t30, 1)
   AIE.shimDMA(%t30) {
-    AIE.dmaStart(MM2S0, ^bb1, ^end)
+    AIE.dmaStart(MM2S, 0, ^bb1, ^end)
   ^bb1:
     AIE.useLock(%l30_0, Acquire, 1)
     // This should fail because only one state can be acquired in a ShimBd

--- a/test/xaie_target/test_error_shimdma_multi_state.mlir
+++ b/test/xaie_target/test_error_shimdma_multi_state.mlir
@@ -15,7 +15,7 @@ module @test_error_shimdma_multi_state {
   %t30 = AIE.tile(3, 0)
   %l30_0 = AIE.lock(%t30, 0)
   AIE.shimDMA(%t30) {
-    AIE.dmaStart(MM2S0, ^bb1, ^end)
+    AIE.dmaStart(MM2S, 0, ^bb1, ^end)
   ^bb1:
     AIE.useLock(%l30_0, Acquire, 0)
     // This should fail because only one lock can be used in a ShimBd

--- a/test/xaie_target/test_xaie1.mlir
+++ b/test/xaie_target/test_xaie1.mlir
@@ -28,7 +28,7 @@ module @test_xaie1 {
   %l33_0 = AIE.lock(%t33, 0)
 
   %m33 = AIE.mem(%t33) {
-      %srcDma = AIE.dmaStart(MM2S0, ^bd0, ^end)
+      %srcDma = AIE.dmaStart(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l33_0, Acquire, 0)
       AIE.dmaBd(<%buf33_1 : memref<256xi32>, 0, 256>, 0)

--- a/test/xaie_target/test_xaie2.mlir
+++ b/test/xaie_target/test_xaie2.mlir
@@ -36,7 +36,7 @@ module @test_xaie2 {
   %l33_1 = AIE.lock(%t33, 1)
 
   %m33 = AIE.mem(%t33) {
-      %srcDma = AIE.dmaStart(S2MM0, ^bd0, ^end)
+      %srcDma = AIE.dmaStart(S2MM, 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l33_0, Acquire, 0)
       AIE.dmaBd(<%buf33_0 : memref<256xi32>, 0, 256>, 0)

--- a/test/xaie_target/test_xaie3.mlir
+++ b/test/xaie_target/test_xaie3.mlir
@@ -25,7 +25,7 @@ module @test_xaie3 {
   %l33_0 = AIE.lock(%t33, 0)
 
   %m33 = AIE.mem(%t33) {
-      %srcDma = AIE.dmaStart(MM2S0, ^bd0, ^end)
+      %srcDma = AIE.dmaStart(MM2S, 0, ^bd0, ^end)
     ^bd0:
       AIE.useLock(%l33_0, Acquire, 1)
       AIE.dmaBd(<%buf33_0 : memref<256xi32>, 0, 256>, 0)

--- a/test/xaie_target/test_xaie4.mlir
+++ b/test/xaie_target/test_xaie4.mlir
@@ -31,9 +31,9 @@ module @test_xaie3 {
   %l33_1 = AIE.lock(%t33, 1)
 
   %m33 = AIE.mem(%t33) {
-      %srcDma = AIE.dmaStart(MM2S0, ^bd0, ^dma0)
+      %srcDma = AIE.dmaStart(MM2S, 0, ^bd0, ^dma0)
     ^dma0:
-      %destDma = AIE.dmaStart(S2MM0, ^bd1, ^end)
+      %destDma = AIE.dmaStart(S2MM, 0, ^bd1, ^end)
     ^bd0:
       AIE.useLock(%l33_0, Acquire, 1)
       AIE.dmaBd(<%buf33_0 : memref<256xi32>, 0, 256>, 0)

--- a/test/xaie_target/tileDMA.mlir
+++ b/test/xaie_target/tileDMA.mlir
@@ -24,7 +24,7 @@ module @aie_module  {
   %26 = AIE.buffer(%0) {address = 4352 : i32, sym_name = "buf7"} : memref<64xi32, 2>
   %27 = AIE.lock(%0, 1)
   %28 = AIE.mem(%0)  {
-    %38 = AIE.dmaStart(S2MM0, ^bb1, ^bb3)
+    %38 = AIE.dmaStart(S2MM, 0, ^bb1, ^bb3)
   ^bb1:  // 2 preds: ^bb0, ^bb1
     AIE.useLock(%25, Acquire, 0)
     AIE.dmaBd(<%24 : memref<64xi32, 2>, 0, 64>, 0)
@@ -33,7 +33,7 @@ module @aie_module  {
   ^bb2:  // pred: ^bb3
     AIE.end
   ^bb3:  // pred: ^bb0
-    %39 = AIE.dmaStart(MM2S0, ^bb4, ^bb2)
+    %39 = AIE.dmaStart(MM2S, 0, ^bb4, ^bb2)
   ^bb4:  // 2 preds: ^bb3, ^bb4
     AIE.useLock(%27, Acquire, 1)
     AIE.dmaBd(<%26 : memref<64xi32, 2>, 0, 64>, 0)


### PR DESCRIPTION
This PR proposes that the current implementation for DMAChan be separated into a DMAChannelDir and channelIndex (i.e., "MM2S1" becomes "MM2S" and '1').